### PR TITLE
Return generated key during push for iOS and android

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -227,8 +227,11 @@ firebase.removeEventListener = function (listener, path) {
 firebase.push = function (path, val) {
   return new Promise(function (resolve, reject) {
     try {
-      instance.child(path).push().setValue(firebase.toHashMap(val));
-      resolve();
+      var pushInstance = instance.child(path).push();
+      pushInstance.setValue(firebase.toHashMap(val));
+      resolve({
+        key: pushInstance.getKey()
+      });
     } catch (ex) {
       console.log("Error in firebase.push: " + ex);
       reject(ex);

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -182,8 +182,11 @@ firebase.addValueEventListener = function (updateCallback, path) {
 firebase.push = function (path, val) {
   return new Promise(function (resolve, reject) {
     try {
-      instance.childByAppendingPath(path).childByAutoId().setValue(val);
-      resolve();
+      var ref = instance.childByAppendingPath(path).childByAutoId();
+      ref.setValue(val);
+      resolve({
+        key: ref.key
+      });
     } catch (ex) {
       console.log("Error in firebase.push: " + ex);
       reject(ex);


### PR DESCRIPTION
Updated push for ios and android to return the key created.  Returned key in an object to be consistent with other resolve methods throughout the code. Incorporated other commit for android code, but added the key-in-object consistency to that also.