### PR TITLE
Added update method to list of available commands

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -251,6 +251,18 @@ firebase.setValue = function (path, val) {
   });
 };
 
+firebase.update = function (path, val) {
+    return new Promise(function (resolve, reject) {
+        try {
+            instance.child(path).updateChildren(firebase.toHashMap(val));
+            resolve();
+        } catch (ex) {
+            console.log("Error in firebase.update: " + ex);
+            reject(ex);
+        }
+    });
+};
+
 firebase.query = function (updateCallback, path, options) {
   return new Promise(function (resolve, reject) {
     try {

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -206,6 +206,18 @@ firebase.setValue = function (path, val) {
   });
 };
 
+firebase.update = function (path, val) {
+    return new Promise(function (resolve, reject) {
+        try {
+            instance.childByAppendingPath(path).updateChildValues(val);
+            resolve();
+        } catch (ex) {
+            console.log("Error in firebase.update: " + ex);
+            reject(ex);
+        }
+    });
+};
+
 firebase.query = function (updateCallback, path, options) {
   return new Promise(function (resolve, reject) {
     try {


### PR DESCRIPTION
I needed to be able to do an update rather than just saving the entire value object, so I've created update methods in both the android and iOS code base, and call the update methods for each.  I have not tested on android, but works successfully for me in iOS.