### PR TITLE
iOSSimulatorFlush for known iOS Simulator issue with invalid_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,19 @@ On the simulator you may see this message if you have more than one app with the
 
 ```
 [FirebaseDatabase] Authentication failed: invalid_token (Invalid claim 'aud' in auth token.)
+or
+[FirebaseDatabase] Authentication failed: invalid_token (audience was project 'firegroceries-904d0' but should have been project 'your-firebase-project')
 ```
 
 This is [a known issue in the Firebase SDK](http://stackoverflow.com/questions/37857131/swift-firebase-database-invalid-token-error).
-I always use a real device to avoid this problem.
+I always use a real device to avoid this problem, but you can pass an 'iOSSimulatorFlush' option to init.
+```
+firebase.init({
+  // Optionally pass in properties for database, authentication and cloud messaging,
+  // see their respective docs and 'iOSSimulatorFlush' to flush token before init.
+  iOSSimulatorFlush: true
+}).then()
+```
 
 ## Known issues on Android
 

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -244,6 +244,19 @@ firebase.init = function (arg) {
       
       firebase.instance = FIRDatabase.database().reference();
 
+      if (arg.iOSEmulatorFlush) {
+        try {
+          // Attempt to sign out before initializing, useful in case previous 
+          // project token is cached which leads to following type of error:
+          // "[FirebaseDatabase] Authentication failed: invalid_token ..."
+          console.log('Attempting to sign out of Firebase before init');
+          FIRAuth.auth().signOut();
+          console.log('Sign out of Firebase successful');
+        } catch(signOutErr) {
+          console.log('Sign out of Firebase error: ' + signOutErr);
+        }
+      }
+
       if (arg.onAuthStateChanged) {
         firebase.authStateListener = function(auth, user) {
           arg.onAuthStateChanged({


### PR DESCRIPTION
When using the [angular-firebase branch](https://github.com/NativeScript/sample-Groceries/tree/angular-firebase) of the [NativeScript/sample-Groceries repo](https://github.com/NativeScript/sample-Groceries), I switched the config's `apiURL` to my own firebase project and received the invalid_token issue with my iOS Simulator, which was very similar to your documented Known Issues in the readme. Adding an option to `init` named `iOSSimulatorFlush` to try to call `auth().signOut` resolves the issue with the simulator holding onto an invalid_token. 

