### PR TITLE
Correct iOSEmulatorFlush misspelling in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ or
 ```
 
 This is [a known issue in the Firebase SDK](http://stackoverflow.com/questions/37857131/swift-firebase-database-invalid-token-error).
-I always use a real device to avoid this problem, but you can pass an 'iOSSimulatorFlush' option to init.
+I always use a real device to avoid this problem, but you can pass an 'iOSEmulatorFlush' option to init.
 ```
 firebase.init({
   // Optionally pass in properties for database, authentication and cloud messaging,
-  // see their respective docs and 'iOSSimulatorFlush' to flush token before init.
-  iOSSimulatorFlush: true
+  // see their respective docs and 'iOSEmulatorFlush' to flush token before init.
+  iOSEmulatorFlush: true
 }).then()
 ```
 


### PR DESCRIPTION
This fixes a misspelling in the readme from PR https://github.com/EddyVerbruggen/nativescript-plugin-firebase/pull/66 which incorrectly referred to new option as iOSSimulatorFlush instead of iOSEmulatorFlush in the readme. 