### PR TITLE
Allow users to pass scope for Facebook Authentication

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -187,7 +187,8 @@ Then add the following lines to your code and check for setup instructions for y
 
 ```js
   firebase.login({
-    type: firebase.LoginType.FACEBOOK
+    type: firebase.LoginType.FACEBOOK,
+    scope: ['public_profile', 'email'] // optional: defaults
   }).then(
       function (result) {
         JSON.stringify(result);
@@ -197,6 +198,8 @@ Then add the following lines to your code and check for setup instructions for y
       }
   )
 ```
+
+For a complete list of the available scope permissions, visit Facebook's documentation: https://developers.facebook.com/docs/facebook-login/permissions. 
 
 #### iOS
  If you want to use it for iOS open the `Podfile` in the plugin's `platforms/ios` folder and uncomment the Facebook line (you can't miss it).

--- a/firebase.android.js
+++ b/firebase.android.js
@@ -307,7 +307,7 @@ firebase.getRemoteConfig = function (arg) {
         .build();
       firebaseRemoteConfig.setConfigSettings(remoteConfigSettings);
 
-      var defaults = firebase.getRemoteConfigDefaults(arg.properties);
+      var defaults = firebase.getRemoteConfigDefaults(arg.properties);      
       firebaseRemoteConfig.setDefaults(firebase.toHashMap(defaults));
 
       var returnMethod = function (throttled) {
@@ -362,7 +362,7 @@ firebase.getRemoteConfig = function (arg) {
         _resolve();
       } else {
         // if this is called before application.start() wait for the event to fire
-        appModule.on(appModule.launchEvent, _resolve);
+        appModule.on(appModule.launchEvent, _resolve);      
       }
     } catch (ex) {
       console.log("Error in firebase.getRemoteConfig: " + ex);
@@ -509,13 +509,7 @@ firebase.login = function (arg) {
             })
           );
 
-          var scope = ["public_profile", "email"];
-
-          if(args.scope) {
-            scope = args.scope;
-          }
-
-          var permissions = utils.ad.collections.stringArrayToStringSet(scope);
+          var permissions = utils.ad.collections.stringArrayToStringSet(["public_profile", "email"]);
           var activity = appModule.android.foregroundActivity;
           fbLoginManager.logInWithReadPermissions(activity, permissions);
 
@@ -530,7 +524,7 @@ firebase.login = function (arg) {
           _resolve();
         } else {
           // if this is called before application.start() wait for the event to fire
-          appModule.on(appModule.launchEvent, _resolve);
+          appModule.on(appModule.launchEvent, _resolve);      
         }
       } catch (ex) {
         console.log("Error in firebase.login: " + ex);

--- a/firebase.android.js
+++ b/firebase.android.js
@@ -511,8 +511,8 @@ firebase.login = function (arg) {
 
           var scope = ["public_profile", "email"];
 
-          if(args.scope) {
-            scope = args.scope;
+          if(arg.scope) {
+            scope = arg.scope;
           }
 
           var permissions = utils.ad.collections.stringArrayToStringSet(scope);

--- a/firebase.android.js
+++ b/firebase.android.js
@@ -307,7 +307,7 @@ firebase.getRemoteConfig = function (arg) {
         .build();
       firebaseRemoteConfig.setConfigSettings(remoteConfigSettings);
 
-      var defaults = firebase.getRemoteConfigDefaults(arg.properties);      
+      var defaults = firebase.getRemoteConfigDefaults(arg.properties);
       firebaseRemoteConfig.setDefaults(firebase.toHashMap(defaults));
 
       var returnMethod = function (throttled) {
@@ -362,7 +362,7 @@ firebase.getRemoteConfig = function (arg) {
         _resolve();
       } else {
         // if this is called before application.start() wait for the event to fire
-        appModule.on(appModule.launchEvent, _resolve);      
+        appModule.on(appModule.launchEvent, _resolve);
       }
     } catch (ex) {
       console.log("Error in firebase.getRemoteConfig: " + ex);
@@ -509,7 +509,13 @@ firebase.login = function (arg) {
             })
           );
 
-          var permissions = utils.ad.collections.stringArrayToStringSet(["public_profile", "email"]);
+          var scope = ["public_profile", "email"];
+
+          if(args.scope) {
+            scope = args.scope;
+          }
+
+          var permissions = utils.ad.collections.stringArrayToStringSet(scope);
           var activity = appModule.android.foregroundActivity;
           fbLoginManager.logInWithReadPermissions(activity, permissions);
 
@@ -524,7 +530,7 @@ firebase.login = function (arg) {
           _resolve();
         } else {
           // if this is called before application.start() wait for the event to fire
-          appModule.on(appModule.launchEvent, _resolve);      
+          appModule.on(appModule.launchEvent, _resolve);
         }
       } catch (ex) {
         console.log("Error in firebase.login: " + ex);

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -553,7 +553,7 @@ firebase.login = function (arg) {
         }
 
         fbSDKLoginManager.logInWithReadPermissionsFromViewControllerHandler(
-            scope, // TODO allow user to pass this in
+            scope,
             null, // the viewcontroller param can be null since by default topmost is taken
             onFacebookCompletion);
 

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -14,7 +14,7 @@ firebase._addObserver = function (eventName, callback) {
 
 firebase.addAppDelegateMethods = function(appDelegate) {
 
-  // we need the launchOptions for this one so it's a bit hard to use the UIApplicationDidFinishLaunchingNotification pattern we're using for other things 
+  // we need the launchOptions for this one so it's a bit hard to use the UIApplicationDidFinishLaunchingNotification pattern we're using for other things
   appDelegate.prototype.applicationDidFinishLaunchingWithOptions = function (application, launchOptions) {
     // Firebase Facebook authentication
     if (typeof(FBSDKApplicationDelegate) !== "undefined") {
@@ -33,7 +33,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
   };
 
   // making this conditional to avoid http://stackoverflow.com/questions/37428539/firebase-causes-issue-missing-push-notification-entitlement-after-delivery-to ?
-  if (typeof(FIRMessaging) !== "undefined") { 
+  if (typeof(FIRMessaging) !== "undefined") {
      appDelegate.prototype.applicationDidReceiveRemoteNotificationFetchCompletionHandler = function (application, userInfo, completionHandler) {
       completionHandler(UIBackgroundFetchResultNewData);
       var userInfoJSON = firebase.toJsObject(userInfo);
@@ -48,7 +48,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
         }
       } else {
         userInfoJSON.foreground = false;
-        firebase._pendingNotifications.push(userInfoJSON); 
+        firebase._pendingNotifications.push(userInfoJSON);
       }
     };
   }
@@ -158,7 +158,7 @@ firebase._processPendingNotifications = function() {
         __.prototype = b.prototype;
         d.prototype = new __();
     };
-    
+
     var appDelegate = (function (_super) {
         __extends(appDelegate, _super);
         function appDelegate() {
@@ -230,7 +230,7 @@ firebase.init = function (arg) {
   return new Promise(function (resolve, reject) {
     try {
       if (firebase.instance !== null) {
-        // if we would run 'FIRApp.configure()' again the app would crash, so: 
+        // if we would run 'FIRApp.configure()' again the app would crash, so:
         reject("You already ran init");
         return;
       }
@@ -242,12 +242,12 @@ firebase.init = function (arg) {
       if (arg.persist) {
         FIRDatabase.database().persistenceEnabled = true;
       }
-      
+
       firebase.instance = FIRDatabase.database().reference();
 
       if (arg.iOSEmulatorFlush) {
         try {
-          // Attempt to sign out before initializing, useful in case previous 
+          // Attempt to sign out before initializing, useful in case previous
           // project token is cached which leads to following type of error:
           // "[FirebaseDatabase] Authentication failed: invalid_token ..."
           console.log('Attempting to sign out of Firebase before init');
@@ -286,11 +286,11 @@ firebase.init = function (arg) {
       // Firebase notifications (FCM)
       if (typeof(FIRMessaging) !== "undefined") {
         firebase._addObserver(kFIRInstanceIDTokenRefreshNotification, firebase._onTokenRefreshNotification);
-        
+
         if (arg.onMessageReceivedCallback !== undefined) {
           firebase.addOnMessageReceivedCallback(arg.onMessageReceivedCallback);
         }
-        
+
         if (arg.onPushTokenReceivedCallback !== undefined) {
           firebase.addOnPushTokenReceivedCallback(arg.onPushTokenReceivedCallback);
         }
@@ -303,7 +303,7 @@ firebase.init = function (arg) {
           return;
         }
         firebase.storage = FIRStorage.storage().referenceForURL(arg.storageBucket);
-      } 
+      }
 
       resolve(firebase.instance);
     } catch (ex) {
@@ -370,7 +370,7 @@ firebase.getRemoteConfig = function (arg) {
 
         if (remoteConfigFetchStatus == FIRRemoteConfigFetchStatusSuccess ||
             remoteConfigFetchStatus == FIRRemoteConfigFetchStatusThrottled) {
-          
+
           var activated = firebaseRemoteConfig.activateFetched();
 
           var result = {
@@ -513,7 +513,7 @@ firebase.login = function (arg) {
           reject("Facebook SDK not installed - see Podfile");
           return;
         }
-        
+
         var onFacebookCompletion = function(fbSDKLoginManagerLoginResult, error) {
           if (error) {
             console.log("Facebook login error " + error);
@@ -547,8 +547,14 @@ firebase.login = function (arg) {
         var fbSDKLoginManager = FBSDKLoginManager.new();
         //fbSDKLoginManager.loginBehavior = FBSDKLoginBehavior.Web;
 
+        var scope = ["public_profile", "email"];
+
+        if(args.scope) {
+          scope = args.scope;
+        }
+
         fbSDKLoginManager.logInWithReadPermissionsFromViewControllerHandler(
-            ["public_profile", "email"], // TODO allow user to pass this in
+            scope, // TODO allow user to pass this in
             null, // the viewcontroller param can be null since by default topmost is taken
             onFacebookCompletion);
 
@@ -782,7 +788,7 @@ firebase.query = function (updateCallback, path, options) {
       }
 
       var query;
-      
+
       // orderBy
       if (options.orderBy.type === firebase.QueryOrderByType.KEY) {
         query = where.queryOrderedByKey();

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -14,7 +14,7 @@ firebase._addObserver = function (eventName, callback) {
 
 firebase.addAppDelegateMethods = function(appDelegate) {
 
-  // we need the launchOptions for this one so it's a bit hard to use the UIApplicationDidFinishLaunchingNotification pattern we're using for other things
+  // we need the launchOptions for this one so it's a bit hard to use the UIApplicationDidFinishLaunchingNotification pattern we're using for other things 
   appDelegate.prototype.applicationDidFinishLaunchingWithOptions = function (application, launchOptions) {
     // Firebase Facebook authentication
     if (typeof(FBSDKApplicationDelegate) !== "undefined") {
@@ -33,7 +33,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
   };
 
   // making this conditional to avoid http://stackoverflow.com/questions/37428539/firebase-causes-issue-missing-push-notification-entitlement-after-delivery-to ?
-  if (typeof(FIRMessaging) !== "undefined") {
+  if (typeof(FIRMessaging) !== "undefined") { 
      appDelegate.prototype.applicationDidReceiveRemoteNotificationFetchCompletionHandler = function (application, userInfo, completionHandler) {
       completionHandler(UIBackgroundFetchResultNewData);
       var userInfoJSON = firebase.toJsObject(userInfo);
@@ -48,7 +48,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
         }
       } else {
         userInfoJSON.foreground = false;
-        firebase._pendingNotifications.push(userInfoJSON);
+        firebase._pendingNotifications.push(userInfoJSON); 
       }
     };
   }
@@ -158,7 +158,7 @@ firebase._processPendingNotifications = function() {
         __.prototype = b.prototype;
         d.prototype = new __();
     };
-
+    
     var appDelegate = (function (_super) {
         __extends(appDelegate, _super);
         function appDelegate() {
@@ -230,7 +230,7 @@ firebase.init = function (arg) {
   return new Promise(function (resolve, reject) {
     try {
       if (firebase.instance !== null) {
-        // if we would run 'FIRApp.configure()' again the app would crash, so:
+        // if we would run 'FIRApp.configure()' again the app would crash, so: 
         reject("You already ran init");
         return;
       }
@@ -242,12 +242,12 @@ firebase.init = function (arg) {
       if (arg.persist) {
         FIRDatabase.database().persistenceEnabled = true;
       }
-
+      
       firebase.instance = FIRDatabase.database().reference();
 
       if (arg.iOSEmulatorFlush) {
         try {
-          // Attempt to sign out before initializing, useful in case previous
+          // Attempt to sign out before initializing, useful in case previous 
           // project token is cached which leads to following type of error:
           // "[FirebaseDatabase] Authentication failed: invalid_token ..."
           console.log('Attempting to sign out of Firebase before init');
@@ -286,11 +286,11 @@ firebase.init = function (arg) {
       // Firebase notifications (FCM)
       if (typeof(FIRMessaging) !== "undefined") {
         firebase._addObserver(kFIRInstanceIDTokenRefreshNotification, firebase._onTokenRefreshNotification);
-
+        
         if (arg.onMessageReceivedCallback !== undefined) {
           firebase.addOnMessageReceivedCallback(arg.onMessageReceivedCallback);
         }
-
+        
         if (arg.onPushTokenReceivedCallback !== undefined) {
           firebase.addOnPushTokenReceivedCallback(arg.onPushTokenReceivedCallback);
         }
@@ -303,7 +303,7 @@ firebase.init = function (arg) {
           return;
         }
         firebase.storage = FIRStorage.storage().referenceForURL(arg.storageBucket);
-      }
+      } 
 
       resolve(firebase.instance);
     } catch (ex) {
@@ -370,7 +370,7 @@ firebase.getRemoteConfig = function (arg) {
 
         if (remoteConfigFetchStatus == FIRRemoteConfigFetchStatusSuccess ||
             remoteConfigFetchStatus == FIRRemoteConfigFetchStatusThrottled) {
-
+          
           var activated = firebaseRemoteConfig.activateFetched();
 
           var result = {
@@ -513,7 +513,7 @@ firebase.login = function (arg) {
           reject("Facebook SDK not installed - see Podfile");
           return;
         }
-
+        
         var onFacebookCompletion = function(fbSDKLoginManagerLoginResult, error) {
           if (error) {
             console.log("Facebook login error " + error);
@@ -547,14 +547,8 @@ firebase.login = function (arg) {
         var fbSDKLoginManager = FBSDKLoginManager.new();
         //fbSDKLoginManager.loginBehavior = FBSDKLoginBehavior.Web;
 
-        var scope = ["public_profile", "email"];
-
-        if(args.scope) {
-          scope = args.scope;
-        }
-
         fbSDKLoginManager.logInWithReadPermissionsFromViewControllerHandler(
-            scope, // TODO allow user to pass this in
+            ["public_profile", "email"], // TODO allow user to pass this in
             null, // the viewcontroller param can be null since by default topmost is taken
             onFacebookCompletion);
 
@@ -788,7 +782,7 @@ firebase.query = function (updateCallback, path, options) {
       }
 
       var query;
-
+      
       // orderBy
       if (options.orderBy.type === firebase.QueryOrderByType.KEY) {
         query = where.queryOrderedByKey();

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -14,7 +14,7 @@ firebase._addObserver = function (eventName, callback) {
 
 firebase.addAppDelegateMethods = function(appDelegate) {
 
-  // we need the launchOptions for this one so it's a bit hard to use the UIApplicationDidFinishLaunchingNotification pattern we're using for other things 
+  // we need the launchOptions for this one so it's a bit hard to use the UIApplicationDidFinishLaunchingNotification pattern we're using for other things
   appDelegate.prototype.applicationDidFinishLaunchingWithOptions = function (application, launchOptions) {
     // Firebase Facebook authentication
     if (typeof(FBSDKApplicationDelegate) !== "undefined") {
@@ -33,7 +33,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
   };
 
   // making this conditional to avoid http://stackoverflow.com/questions/37428539/firebase-causes-issue-missing-push-notification-entitlement-after-delivery-to ?
-  if (typeof(FIRMessaging) !== "undefined") { 
+  if (typeof(FIRMessaging) !== "undefined") {
      appDelegate.prototype.applicationDidReceiveRemoteNotificationFetchCompletionHandler = function (application, userInfo, completionHandler) {
       completionHandler(UIBackgroundFetchResultNewData);
       var userInfoJSON = firebase.toJsObject(userInfo);
@@ -48,7 +48,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
         }
       } else {
         userInfoJSON.foreground = false;
-        firebase._pendingNotifications.push(userInfoJSON); 
+        firebase._pendingNotifications.push(userInfoJSON);
       }
     };
   }
@@ -158,7 +158,7 @@ firebase._processPendingNotifications = function() {
         __.prototype = b.prototype;
         d.prototype = new __();
     };
-    
+
     var appDelegate = (function (_super) {
         __extends(appDelegate, _super);
         function appDelegate() {
@@ -230,7 +230,7 @@ firebase.init = function (arg) {
   return new Promise(function (resolve, reject) {
     try {
       if (firebase.instance !== null) {
-        // if we would run 'FIRApp.configure()' again the app would crash, so: 
+        // if we would run 'FIRApp.configure()' again the app would crash, so:
         reject("You already ran init");
         return;
       }
@@ -242,12 +242,12 @@ firebase.init = function (arg) {
       if (arg.persist) {
         FIRDatabase.database().persistenceEnabled = true;
       }
-      
+
       firebase.instance = FIRDatabase.database().reference();
 
       if (arg.iOSEmulatorFlush) {
         try {
-          // Attempt to sign out before initializing, useful in case previous 
+          // Attempt to sign out before initializing, useful in case previous
           // project token is cached which leads to following type of error:
           // "[FirebaseDatabase] Authentication failed: invalid_token ..."
           console.log('Attempting to sign out of Firebase before init');
@@ -286,11 +286,11 @@ firebase.init = function (arg) {
       // Firebase notifications (FCM)
       if (typeof(FIRMessaging) !== "undefined") {
         firebase._addObserver(kFIRInstanceIDTokenRefreshNotification, firebase._onTokenRefreshNotification);
-        
+
         if (arg.onMessageReceivedCallback !== undefined) {
           firebase.addOnMessageReceivedCallback(arg.onMessageReceivedCallback);
         }
-        
+
         if (arg.onPushTokenReceivedCallback !== undefined) {
           firebase.addOnPushTokenReceivedCallback(arg.onPushTokenReceivedCallback);
         }
@@ -303,7 +303,7 @@ firebase.init = function (arg) {
           return;
         }
         firebase.storage = FIRStorage.storage().referenceForURL(arg.storageBucket);
-      } 
+      }
 
       resolve(firebase.instance);
     } catch (ex) {
@@ -370,7 +370,7 @@ firebase.getRemoteConfig = function (arg) {
 
         if (remoteConfigFetchStatus == FIRRemoteConfigFetchStatusSuccess ||
             remoteConfigFetchStatus == FIRRemoteConfigFetchStatusThrottled) {
-          
+
           var activated = firebaseRemoteConfig.activateFetched();
 
           var result = {
@@ -513,7 +513,7 @@ firebase.login = function (arg) {
           reject("Facebook SDK not installed - see Podfile");
           return;
         }
-        
+
         var onFacebookCompletion = function(fbSDKLoginManagerLoginResult, error) {
           if (error) {
             console.log("Facebook login error " + error);
@@ -546,9 +546,14 @@ firebase.login = function (arg) {
         // this requires you to set the appid and customurlscheme in app_resources/.plist
         var fbSDKLoginManager = FBSDKLoginManager.new();
         //fbSDKLoginManager.loginBehavior = FBSDKLoginBehavior.Web;
+        var scope = ["public_profile", "email"];
+
+        if(args.scope) {
+          scope = args.scope;
+        }
 
         fbSDKLoginManager.logInWithReadPermissionsFromViewControllerHandler(
-            ["public_profile", "email"], // TODO allow user to pass this in
+            scope, // TODO allow user to pass this in
             null, // the viewcontroller param can be null since by default topmost is taken
             onFacebookCompletion);
 
@@ -782,7 +787,7 @@ firebase.query = function (updateCallback, path, options) {
       }
 
       var query;
-      
+
       // orderBy
       if (options.orderBy.type === firebase.QueryOrderByType.KEY) {
         query = where.queryOrderedByKey();

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -548,8 +548,8 @@ firebase.login = function (arg) {
         //fbSDKLoginManager.loginBehavior = FBSDKLoginBehavior.Web;
         var scope = ["public_profile", "email"];
 
-        if(args.scope) {
-          scope = args.scope;
+        if(arg.scope) {
+          scope = arg.scope;
         }
 
         fbSDKLoginManager.logInWithReadPermissionsFromViewControllerHandler(


### PR DESCRIPTION
Checks for an optional `scope` parameter on the `arg` object of the login method. Sets the defaults to `public_profile` and `email`, but allows a user to request any required scope for their application. 