### PR TITLE
Trying to fix toJsObject for Android

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -76,7 +76,10 @@ firebase.toJsObject = function(javaObj) {
   var node;
   switch (javaObj.getClass().getName()) {
     case 'java.lang.Boolean':
-      return Boolean(String(javaObj));
+      var str = String(javaObj);
+      return Boolean(!!(str=="True" || str=="true"));
+    case 'java.lang.String':
+      return String(javaObj);
     case 'java.lang.Long':
     case 'java.lang.Double':
       return Number(String(javaObj));
@@ -95,17 +98,8 @@ firebase.toJsObject = function(javaObj) {
           case 'java.util.HashMap$HashMapEntry':
             node[item.getKey()] = firebase.toJsObject(item.getValue());
             break;
-          case 'java.lang.String':
-            node[item.getKey()] = String(item.getValue());
-            break;
-          case 'java.lang.Boolean':
-            node[item.getKey()] = Boolean(String(item.getValue()));
-            break;
-          case 'java.lang.Long':
-          case 'java.lang.Double':
-            node[item.getKey()] = Number(String(item.getValue()));
-            break;
           default:
+            //we should never reach this line?!
             node[item.getKey()] = item.getValue();
         }
       }


### PR DESCRIPTION
I found a bug, that causes db-received booleans to have always the value True on android.

The line which causes the problem:
firebase.android.js:79 `return Boolean(String(javaObj));`

According to the [Reference Documentaiton of Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean#Creating_Boolean_objects_with_an_initial_value_of_true) `Boolean('false')` will create a Boolean with the value `true`.

I changed the line to 
```
var str = String(javaObj);
return Boolean(!!(str=="True" || str=="true"));
```
but I haven't gotten around to test it thoroughly. 
Also I have made some other simplifications which need to be reviewed by you.
