### PR TITLE
Post Install Concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
       "ios": "1.7.0"
     }
   },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/eddyverbruggen/nativescript-plugin-firebase.git"
@@ -34,5 +37,9 @@
   "bugs": {
     "url": "https://github.com/eddyverbruggen/nativescript-plugin-firebase/issues"
   },
-  "homepage": "https://github.com/eddyverbruggen/nativescript-plugin-firebase"
+  "homepage": "https://github.com/eddyverbruggen/nativescript-plugin-firebase",
+  "dependencies": {
+    "fs": "0.0.2",
+    "prompt": "^1.0.0"
+  }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,197 @@
+var fs = require('fs');
+var prompt = require('prompt');
+
+// Default settings for using ios and android with Firebase
+var usingiOS = false, usingAndroid = false;
+
+// The directories where the Podfile and include.gradle are stored
+var directories = {
+    ios: './platforms/ios',
+    android: './platforms/android'
+}
+
+console.log('NativeScript Firebase Plugin Installation');
+prompt.start();
+askiOSPrompt();
+
+/**
+ * Prompt the user if they are integrating Firebase with iOS
+ */
+function askiOSPrompt() {
+    prompt.get({
+        name: 'using_ios',
+        description: 'Are you using iOS (y/n)',
+        default: 'y',
+    }, function (err, result) {
+        if (err) {
+            return console.log(err);
+        }
+        if (result.using_ios && result.using_ios.toLowerCase() === 'y') {
+            usingiOS = true;
+        }
+        askAndroidPrompt();
+    });
+}
+
+/**
+ * Prompt the user if they are integrating Firebase with Android
+ */
+function askAndroidPrompt() {
+    prompt.get({
+        name: 'using_android',
+        description: 'Are you using Android (y/n)',
+        default: 'y',
+    }, function (err, result) {
+        if (err) {
+            return console.log(err);
+        }
+        if (result.using_android && result.using_android.toLowerCase() === 'y') {
+            usingAndroid = true;
+        }
+        if(usingiOS || usingAndroid) {
+            promptQuestions();
+        }
+    });
+}
+
+/**
+ * Prompt the user through the configurable firebase add-on services
+ */
+function promptQuestions() {
+    prompt.get([{
+        name: 'remote_config',
+        description: 'Are you using Firebase RemoteConfig (y/n)',
+        default: 'n',
+    }, {
+        name: 'messaging',
+        description: 'Are you using Firebase Messaging (y/n)',
+        default: 'n'
+    }, {
+        name: 'storage',
+        description: 'Are you using Firebase Storage (y/n)',
+        default: 'n'
+    }, {
+        name: 'facebook_auth',
+        description: 'Are you using Facebook Authentication (y/n)',
+        default: 'n'
+    }, {
+        name: 'google_auth',
+        description: 'Are you using Google Authentication (y/n)',
+        default: 'n'
+    }], function (err, result) {
+        if (err) {
+            return console.log(err);
+        }
+        if(usingiOS) {
+            writePodFile(result);
+        }
+        if(usingAndroid) {
+            writeGradleFile(result);
+        }
+    });
+}
+
+/**
+ * Create the iOS PodFile for installing the Firebase iOS dependencies and service dependencies
+ *
+ * @param {any} result The answers to the micro-service prompts
+ */
+function writePodFile(result) {
+    if(!fs.existsSync(directories.ios)) {
+        fs.mkdirSync(directories.ios);
+    }
+    fs.writeFile(directories.ios + '/Podfile',
+    `pod 'Firebase', '~> 3.3.0'
+    pod 'Firebase/Database'
+    pod 'Firebase/Auth'
+    pod 'Firebase/Crash'
+
+    # Uncomment if you want to enable Remote Config
+    ` + (isSelected(result.remote_config) ? `` : `#`) + `pod 'Firebase/RemoteConfig'
+
+    # Uncomment if you want to enable FCM (Firebase Cloud Messaging)
+    ` + (isSelected(result.messaging) ? `` : `#`) + `pod 'Firebase/Messaging'
+
+    # Uncomment if you want to enable Firebase Storage
+    ` + (isSelected(result.storage) ? `` : `#`) + `pod 'Firebase/Storage'
+
+    # Uncomment if you want to enable Facebook Authentication
+    ` + (isSelected(result.facebook_auth) ? `` : `#`) + `pod 'FBSDKCoreKit'
+    ` + (isSelected(result.facebook_auth) ? `` : `#`) + `pod 'FBSDKLoginKit'
+
+    # Uncomment if you want to enable Google Authentication
+    ` + (isSelected(result.google_auth) ? `` : `#`) + `pod 'GoogleSignIn'`, function(err) {
+        if(err) {
+            return console.log(err);
+        }
+        console.log('Successfully created iOS (Pod) file.');
+    });
+}
+
+/**
+ * Create the Android Gradle for installing the Firebase Android dependencies and service dependencies
+ *
+ * @param {any} result The answers to the micro-service prompts
+ */
+function writeGradleFile(result) {
+     if(!fs.existsSync(directories.android)) {
+        fs.mkdirSync(directories.android);
+    }
+    fs.writeFile(directories.android + '/include.gradle',
+    `
+    android {
+        productFlavors {
+            "fireb" {
+                dimension "fireb"
+            }
+        }
+    }
+
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
+
+    dependencies {
+        // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
+        compile "com.google.firebase:firebase-core:9.4.0"
+        compile "com.google.firebase:firebase-database:9.4.0"
+        compile "com.google.firebase:firebase-auth:9.4.0"
+        compile "com.google.firebase:firebase-crash:9.4.0"
+
+        // for reading google-services.json and configuration
+        compile "com.google.android.gms:play-services-base:9.4.0"
+
+        // Uncomment if you want to use 'Remote Config'
+        ` + (isSelected(result.remote_config) ? `` : `//`) + ` compile "com.google.firebase:firebase-config:9.4.0"
+
+        // Uncomment if you want FCM (Firebase Cloud Messaging)
+        ` + (isSelected(result.messaging) ? `` : `//`) + ` compile "com.google.firebase:firebase-messaging:9.4.0"
+
+        // Uncomment if you want Google Cloud Storage
+        ` + (isSelected(result.storage) ? `` : `//`) + ` compile 'com.google.firebase:firebase-storage:9.4.0'
+
+        // Uncomment if you need Facebook Authentication
+        ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` compile "com.facebook.android:facebook-android-sdk:4.+"
+
+        // Uncomment if you need Google Sign-In Authentication
+        ` + (isSelected(result.google_auth) ? `` : `//`) + ` compile "com.google.android.gms:play-services-auth:9.4.0"
+
+    }
+    `, function(err) {
+        if(err) {
+            return console.log(err);
+        }
+        console.log('Successfully created Android (include.gradle) file.');
+    });
+}
+
+/**
+ * Determines if the answer validates as selected
+ *
+ * @param {any} value The user input for a prompt
+ * @returns {true} The answer is yes, {false} The answer is no
+ */
+function isSelected(value) {
+    return (value && value.toLowerCase() === 'y')
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var prompt = require('prompt');
 
 // Default settings for using ios and android with Firebase
-var usingiOS = false, usingAndroid = false;
+var usingiOS = false, usingAndroid = false, packageName = 'your.package.name';
 
 // The directories where the Podfile and include.gradle are stored
 var directories = {
@@ -26,7 +26,7 @@ function askiOSPrompt() {
         if (err) {
             return console.log(err);
         }
-        if (result.using_ios && result.using_ios.toLowerCase() === 'y') {
+        if (isSelected(result.using_ios)) {
             usingiOS = true;
         }
         askAndroidPrompt();
@@ -45,11 +45,24 @@ function askAndroidPrompt() {
         if (err) {
             return console.log(err);
         }
-        if (result.using_android && result.using_android.toLowerCase() === 'y') {
+        if (isSelected(result.using_android)) {
             usingAndroid = true;
+            prompt.get({
+                name: 'package_name',
+                description: 'Enter your application id (i.e. your.package.name)',
+                required: true
+            }, function(err, result) {
+                if(err) {
+                    return console.log(err);
+                }
+                packageName = result.package_name;
+                promptQuestions();
+            });
         }
-        if(usingiOS || usingAndroid) {
-            promptQuestions();
+        else {
+            if(usingiOS || usingAndroid) {
+                promptQuestions();
+            }
         }
     });
 }
@@ -72,11 +85,11 @@ function promptQuestions() {
         default: 'n'
     }, {
         name: 'facebook_auth',
-        description: 'Are you using Facebook Authentication (y/n)',
+        description: 'Are you using Firebase Facebook Authentication (y/n)',
         default: 'n'
     }, {
         name: 'google_auth',
-        description: 'Are you using Google Authentication (y/n)',
+        description: 'Are you using Firebase Google Authentication (y/n)',
         default: 'n'
     }], function (err, result) {
         if (err) {
@@ -88,6 +101,7 @@ function promptQuestions() {
         if(usingAndroid) {
             writeGradleFile(result);
         }
+        console.log('Firebase post install completed. To re-run this script, navigate to the root directory of `nativescript-plugin-firebase` in your `node_modules` folder and run: `npm run postinstall`.');
     });
 }
 
@@ -144,6 +158,9 @@ function writeGradleFile(result) {
             "fireb" {
                 dimension "fireb"
             }
+        }
+        defaultConfig {
+            applicationId = "` + packageName + `"
         }
     }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -165,8 +165,8 @@ function writeGradleFile(result) {
     }
 
     repositories {
-        mavenCentral()
         jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var prompt = require('prompt');
 
 // Default settings for using ios and android with Firebase
-var usingiOS = false, usingAndroid = false, packageName = 'your.package.name';
+var usingiOS = false, usingAndroid = false;
 
 // The directories where the Podfile and include.gradle are stored
 var directories = {
@@ -47,22 +47,9 @@ function askAndroidPrompt() {
         }
         if (isSelected(result.using_android)) {
             usingAndroid = true;
-            prompt.get({
-                name: 'package_name',
-                description: 'Enter your application id (i.e. your.package.name)',
-                required: true
-            }, function(err, result) {
-                if(err) {
-                    return console.log(err);
-                }
-                packageName = result.package_name;
-                promptQuestions();
-            });
         }
-        else {
-            if(usingiOS || usingAndroid) {
-                promptQuestions();
-            }
+        if(usingiOS || usingAndroid) {
+            promptQuestions();
         }
     });
 }
@@ -158,9 +145,6 @@ function writeGradleFile(result) {
             "fireb" {
                 dimension "fireb"
             }
-        }
-        defaultConfig {
-            applicationId = "` + packageName + `"
         }
     }
 


### PR DESCRIPTION
Current Situation:
In a multi-developer environment, each developer has to manually configure their `Podfile` and `include.gradle` file to include any of the add-on micro-services that firebase offers. This isn't ideal, because often times users are not aware of these steps when being added to an existing project.

Proposed Solution:
This pull-request contains a post-install script that will run after every installation of the firebase plugin. It prompts the user if they are using iOS and/or Android and then walks the user through the available micro-services. Once the prompts complete, the script will overwrite the `Podfile` and `include.gradle` file with the base dependencies, as well as the selected micro-services. Items that they prompted "n" (no) for, will be commented out as they were previously. 

I'm open feedback and/or changes. I just ran into this issue with my own plugins and found that this was an effective solution for my team environment. 

Concept:
# <img src="http://g.recordit.co/lAvbp4VRPB.gif" />