### PR TITLE
(Bugfix Android) added onCancelled callback to child event listeners

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -759,6 +759,11 @@ firebase._addObservers = function(to, updateCallback) {
     },
     onChildMoved: function (snapshot, previousChildKey) {
       updateCallback(firebase.getCallbackData('ChildMoved', snapshot));
+    },
+    onCancelled: function (databaseError) {
+      updateCallback({
+        error: databaseError.getMessage()
+      });
     }
   });
   to.addChildEventListener(listener);


### PR DESCRIPTION
This fixes `calling js method onCancelled failed` error as described in #95. It happens when a user logs out and is no longer authenticated, but has listeners on authenticated data. The listeners fail, but the app crashes since there is no "onCancelled" handler.

With this fix the app will no longer crash if the listener fails.