### PR TITLE
Some automations for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ We're trying to automate these steps, but for now:
   }
 ```
 
+#### google-services.json
+Firebase configures the native android project using a *google-services.json* file.
+You can place it at `app/App_Resources/Android/google-services.json`.
+
+This plugin adds an after-prepare NativeScript CLI hook that will copy it to the native android project at `platforms/android/google-services.json`.
+
 ## Usage
 
 If you want a quickstart, [clone our demo app](https://github.com/EddyVerbruggen/nativescript-plugin-firebase-demo).

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ We're trying to automate these steps, but for now:
   }
 ```
 
-- Add the very bottom of the same file add
-```
-  apply plugin: "com.google.gms.google-services"
-```
-
 ## Usage
 
 If you want a quickstart, [clone our demo app](https://github.com/EddyVerbruggen/nativescript-plugin-firebase-demo).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ tns plugin add nativescript-plugin-firebase
 ```
 _This will guide you through installing additional components. Check the doc links above to see what's what. You can always change your choices later._
 
+### Config
+If you choose to save your config during the installation, the supported options may be saved in the `firebase.nativescript.json` at the root of your app.
+This is to ensure your app may roundtrip source control and installation on CI won't run the questionary during install.
+
+You can reconfigure the plugin by going to the `node_modules/nativescript-plugin-firebase` and running `npm run config`.
+
+You can also change the configuration by deleting the `firebase.nativescript.json` and reinstalling the plugin.
+
 ### iOS
 [Looking to automate this step](https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/136), but for now, to build with Xcode 8 (iOS 10 SDK), you need to open the Xcode project via the platforms/ios/appname.__xcworkspace__/ file - then select your app's target, capabilities, enable 'Keychain sharing'.
 

--- a/docs/MESSAGING.md
+++ b/docs/MESSAGING.md
@@ -19,8 +19,28 @@ Open `app/App_Resources/iOS/Info.plist` and add this to the bottom:
 ```xml
 <key>UIBackgroundModes</key>
 <array>
-	<string>remote-notification</string>
+    <string>remote-notification</string>
 </array>
+```
+
+For Android you will not get the title and body if the notification was received while the application was in background, but you will get the *data* payload.
+Add the following services in the `app/App_Resources/Android/AndroidManifest.xml` to enable advanced FCM messaging:
+```
+<manifest ... >
+    <application ... >
+        ...
+        <service android:name="org.nativescript.plugins.firebase.MyFirebaseInstanceIDService">
+            <intent-filter>
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
+            </intent-filter>
+        </service>
+        <service android:name="org.nativescript.plugins.firebase.MyFirebaseMessagingService">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+            </intent-filter>
+        </service>
+    </application>
+</manifest>
 ```
 
 #### Provisioning hell

--- a/firebase.android.js
+++ b/firebase.android.js
@@ -15,7 +15,10 @@ var GOOGLE_SIGNIN_INTENT_ID = 123;
   if (typeof(com.google.firebase.messaging) === "undefined") {
     return;
   }
-  appModule.onLaunch = function(intent) {
+  appModule.on("launch", function(args) {
+
+    var intent = args.android;
+
     var extras = intent.getExtras();
     if (extras !== null) {
       var result = {
@@ -40,7 +43,7 @@ var GOOGLE_SIGNIN_INTENT_ID = 123;
         });
       }
     }
-  };
+  });
 
 })();
 

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -78,7 +78,7 @@ firebase.addAppDelegateMethods = function(appDelegate) {
       var aps = userInfo.objectForKey("aps");
       if (aps !== null) {
         var alert = aps.objectForKey("alert");
-        if (alert !== null) {
+        if (alert !== null && alert.objectForKey) {
           userInfoJSON.title = alert.objectForKey("title");
           userInfoJSON.body = alert.objectForKey("body");
         }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nativescript-plugin-firebase",
   "version": "3.7.1",
-  "description" : "Fire. Base. Firebase!",
-  "main" : "firebase.js",
+  "description": "Fire. Base. Firebase!",
+  "main": "firebase.js",
   "typings": "index.d.ts",
   "nativescript": {
     "platforms": {
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "postinstall": "node scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js",
+    "config": "node scripts/postinstall.js config"
   },
   "repository": {
     "type": "git",
@@ -40,6 +41,7 @@
   },
   "homepage": "https://github.com/eddyverbruggen/nativescript-plugin-firebase",
   "dependencies": {
+    "app-root-path": "^2.0.1",
     "prompt": "^1.0.0"
   }
 }

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -38,3 +38,5 @@ dependencies {
 //    compile "com.google.android.gms:play-services-auth:9.6.+"
 
 }
+
+apply plugin: "com.google.gms.google-services"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -19,7 +19,7 @@ var pluginConfigPath = path.join(appRoot, "firebase.nativescript.json");
 var config = {};
 function mergeConfig(result) {
     for (var key in result) {
-        config[key] = result[key];
+        config[key] = isSelected(result[key]);
     }
 }
 function saveConfig() {
@@ -299,5 +299,5 @@ module.exports = function() {
  * @returns {boolean} The answer is yes, {false} The answer is no
  */
 function isSelected(value) {
-    return (value && value.toLowerCase() === 'y')
+    return value === true || (typeof value === "string" && value.toLowerCase() === 'y');
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -102,26 +102,26 @@ function writePodFile(result) {
         fs.mkdirSync(directories.ios);
     }
     fs.writeFile(directories.ios + '/Podfile',
-    `pod 'Firebase', '~> 3.7.0'
-    pod 'Firebase/Database'
-    pod 'Firebase/Auth'
-    #pod 'Firebase/Crash'
+`pod 'Firebase', '~> 3.7.0'
+pod 'Firebase/Database'
+pod 'Firebase/Auth'
+#pod 'Firebase/Crash'
 
-    # Uncomment if you want to enable Remote Config
-    ` + (isSelected(result.remote_config) ? `` : `#`) + `pod 'Firebase/RemoteConfig'
+# Uncomment if you want to enable Remote Config
+` + (isSelected(result.remote_config) ? `` : `#`) + `pod 'Firebase/RemoteConfig'
 
-    # Uncomment if you want to enable FCM (Firebase Cloud Messaging)
-    ` + (isSelected(result.messaging) ? `` : `#`) + `pod 'Firebase/Messaging'
+# Uncomment if you want to enable FCM (Firebase Cloud Messaging)
+` + (isSelected(result.messaging) ? `` : `#`) + `pod 'Firebase/Messaging'
 
-    # Uncomment if you want to enable Firebase Storage
-    ` + (isSelected(result.storage) ? `` : `#`) + `pod 'Firebase/Storage'
+# Uncomment if you want to enable Firebase Storage
+` + (isSelected(result.storage) ? `` : `#`) + `pod 'Firebase/Storage'
 
-    # Uncomment if you want to enable Facebook Authentication
-    ` + (isSelected(result.facebook_auth) ? `` : `#`) + `pod 'FBSDKCoreKit'
-    ` + (isSelected(result.facebook_auth) ? `` : `#`) + `pod 'FBSDKLoginKit'
+# Uncomment if you want to enable Facebook Authentication
+` + (isSelected(result.facebook_auth) ? `` : `#`) + `pod 'FBSDKCoreKit'
+` + (isSelected(result.facebook_auth) ? `` : `#`) + `pod 'FBSDKLoginKit'
 
-    # Uncomment if you want to enable Google Authentication
-    ` + (isSelected(result.google_auth) ? `` : `#`) + `pod 'GoogleSignIn'`, function(err) {
+# Uncomment if you want to enable Google Authentication
+` + (isSelected(result.google_auth) ? `` : `#`) + `pod 'GoogleSignIn'`, function(err) {
         if(err) {
             return console.log(err);
         }
@@ -139,47 +139,49 @@ function writeGradleFile(result) {
         fs.mkdirSync(directories.android);
     }
     fs.writeFile(directories.android + '/include.gradle',
-    `
-    android {
-        productFlavors {
-            "fireb" {
-                dimension "fireb"
-            }
+`
+android {
+    productFlavors {
+        "fireb" {
+            dimension "fireb"
         }
     }
+}
 
-    repositories {
-        jcenter()
-        mavenCentral()
-    }
+repositories {
+    jcenter()
+    mavenCentral()
+}
 
-    dependencies {
-        // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
-        compile "com.google.firebase:firebase-core:9.6.+"
-        compile "com.google.firebase:firebase-database:9.6.+"
-        compile "com.google.firebase:firebase-auth:9.6.+"
-        compile "com.google.firebase:firebase-crash:9.6.+"
+dependencies {
+    // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
+    compile "com.google.firebase:firebase-core:9.6.+"
+    compile "com.google.firebase:firebase-database:9.6.+"
+    compile "com.google.firebase:firebase-auth:9.6.+"
+    compile "com.google.firebase:firebase-crash:9.6.+"
 
-        // for reading google-services.json and configuration
-        compile "com.google.android.gms:play-services-base:9.6.+"
+    // for reading google-services.json and configuration
+    compile "com.google.android.gms:play-services-base:9.6.+"
 
-        // Uncomment if you want to use 'Remote Config'
-        ` + (isSelected(result.remote_config) ? `` : `//`) + ` compile "com.google.firebase:firebase-config:9.6.+"
+    // Uncomment if you want to use 'Remote Config'
+    ` + (isSelected(result.remote_config) ? `` : `//`) + ` compile "com.google.firebase:firebase-config:9.6.+"
 
-        // Uncomment if you want FCM (Firebase Cloud Messaging)
-        ` + (isSelected(result.messaging) ? `` : `//`) + ` compile "com.google.firebase:firebase-messaging:9.6.+"
+    // Uncomment if you want FCM (Firebase Cloud Messaging)
+    ` + (isSelected(result.messaging) ? `` : `//`) + ` compile "com.google.firebase:firebase-messaging:9.6.+"
 
-        // Uncomment if you want Google Cloud Storage
-        ` + (isSelected(result.storage) ? `` : `//`) + ` compile 'com.google.firebase:firebase-storage:9.6.+'
+    // Uncomment if you want Google Cloud Storage
+    ` + (isSelected(result.storage) ? `` : `//`) + ` compile 'com.google.firebase:firebase-storage:9.6.+'
 
-        // Uncomment if you need Facebook Authentication
-        ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` compile "com.facebook.android:facebook-android-sdk:4.+"
+    // Uncomment if you need Facebook Authentication
+    ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` compile "com.facebook.android:facebook-android-sdk:4.+"
 
-        // Uncomment if you need Google Sign-In Authentication
-        ` + (isSelected(result.google_auth) ? `` : `//`) + ` compile "com.google.android.gms:play-services-auth:9.6.+"
+    // Uncomment if you need Google Sign-In Authentication
+    ` + (isSelected(result.google_auth) ? `` : `//`) + ` compile "com.google.android.gms:play-services-auth:9.6.+"
 
-    }
-    `, function(err) {
+}
+
+apply plugin: "com.google.gms.google-services"
+`, function(err) {
         if(err) {
             return console.log(err);
         }


### PR DESCRIPTION
 - Apply plugin for android handled in plugin's include.gradle
 - Initial questionary answers saved to firebase.nativescript.json so it can roundtrip source control without requiring the answers to be replayed. Will survive CI
 - Installed hook that would copy google-services.json from app/App_Resources/Android to platforms/android so it can roundtrip source control and CI
 - Added some missing pieces in the MESSAGING.md with some android services required to handle FCM while app is in background
 - Fixed setting application.onLaunch with adding application.on("launch" so multiple plugins don't defy each-other

Adding buildscript>dependencies>classpath "com.google.gms:google-services:3.0.0" still has to be done by hand in platforms/android or in hook. We ({N}) will have to modify the CLI to make a copy of build.gradle in app/App_Resources/Android/build.gradle in future.