### PR TITLE
Bundle postinstall script dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .DS_Store
 node_modules
+*.tgz
+scripts/postinstall.js

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@ platforms/android/libraryproject/
 docs
 README.md
 CHANGELOG.md
+*.tgz
+scripts/webpack.config.js
+scripts/installer.js
+scripts/winston-mock.js

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     }
   },
   "scripts": {
+    "bundle-installer": "webpack --config scripts/webpack.config.js scripts/installer.js scripts/postinstall.js",
+    "prepublish": "npm run bundle-installer",
     "postinstall": "node scripts/postinstall.js"
   },
   "repository": {
@@ -39,7 +41,8 @@
     "url": "https://github.com/eddyverbruggen/nativescript-plugin-firebase/issues"
   },
   "homepage": "https://github.com/eddyverbruggen/nativescript-plugin-firebase",
-  "dependencies": {
-    "prompt": "^1.0.0"
+  "devDependencies": {
+    "prompt": "^1.0.0",
+    "webpack": "~2.1.0-beta.25"
   }
 }

--- a/scripts/installer.js
+++ b/scripts/installer.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 var prompt = require('prompt');
 
 // Default settings for using ios and android with Firebase
@@ -138,6 +139,8 @@ function writeGradleFile(result) {
      if(!fs.existsSync(directories.android)) {
         fs.mkdirSync(directories.android);
     }
+    console.log(directories.android + '/include.gradle');
+    console.log(path.resolve(directories.android + '/include.gradle'));
     fs.writeFile(directories.android + '/include.gradle',
     `
     android {

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -1,0 +1,20 @@
+var path = require("path");
+var webpack = require("webpack");
+
+module.exports = {
+    target: "node",
+    output: {
+        //some debug info around module imports
+        pathinfo: true
+    },
+    resolve: {
+        alias: {
+            //winston is inherently unpackable. replace with our mock
+            "winston": path.join(__dirname, "winston-mock.js")
+        }
+    },
+    externals: {
+        //pkginfo is unpackable too, but we can replace it with a simple expression
+        "pkginfo": "function(){}"
+    }
+}

--- a/scripts/winston-mock.js
+++ b/scripts/winston-mock.js
@@ -1,0 +1,12 @@
+//Export a Logger-like to avoid crashing winston clients
+module.exports.Logger = function Logger() {};
+module.exports.Logger.prototype = {
+    cli: function() {},
+    help: function() {},
+    input: function() {},
+    error: function() {},
+};
+
+module.exports.transports = {
+    Console: function Console() {}
+};


### PR DESCRIPTION
Fixes tns build errors. #211 

Note that this solution has a small drawback -- plugin developer `npm install` calls will fail due to the postinstall script not being generated yet (generated in the `prepublish` hook). You can either ignore the error or use `npm install --ignore-scripts`