### PR TITLE
Added updateProfile method

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -166,6 +166,21 @@ Don't forget to enable email-password login in your firebase instance.
   );
 ```
 
+#### Updating a profile
+```js
+  firebase.updateProfile({
+    displayName: 'Eddy Verbruggen',
+    photoURL: 'http://provider.com/profiles/eddyverbruggen.png'
+  }).then(
+      function () {
+        // called when update profile was successful
+      },
+      function (errorMessage) {
+        console.log(errorMessage);
+      }
+  );
+```
+
 #### Resetting a password
 ```js
   firebase.resetPassword({

--- a/firebase.android.js
+++ b/firebase.android.js
@@ -890,6 +890,49 @@ firebase.deleteUser = function (arg) {
   });
 };
 
+firebase.updateProfile = function (arg) {
+  return new Promise(function (resolve, reject) {
+    try {
+      if (!arg.displayName && !arg.photoURL) {
+        reject("Updating a profile requires a displayName and / or a photoURL argument");
+      } else {
+        var firebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
+        var user = firebaseAuth.getCurrentUser();
+
+        if (user === null) {
+          reject("No current user");
+          return;
+        }
+
+        var onCompleteListener = new com.google.android.gms.tasks.OnCompleteListener({
+          onComplete: function (task) {
+            if (task.isSuccessful()) {
+              resolve();
+            } else {
+              reject("Updating a profile failed. " + (task.getException() && task.getException().getReason ? task.getException().getReason() : task.getException()));
+            }
+          }
+        });
+
+        var profileUpdateBuilder = new com.google.firebase.auth.UserProfileChangeRequest.Builder();
+
+        if (arg.displayName)
+          profileUpdateBuilder.setDisplayName(arg.displayName)
+
+        if (arg.photoURL)
+          profileUpdateBuilder.setPhotoUri(android.net.Uri.parse(arg.photoURL))
+
+        var profileUpdate = profileUpdateBuilder.build();
+
+        user.updateProfile(profileUpdate).addOnCompleteListener(onCompleteListener);
+      }
+    } catch (ex) {
+      console.log("Error in firebase.updateProfile: " + ex);
+      reject(ex);
+    }
+  });
+};
+
 firebase.keepInSync = function (path, switchOn) {
   return new Promise(function (resolve, reject) {
     try {

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -1005,6 +1005,43 @@ firebase.deleteUser = function (arg) {
   });
 };
 
+firebase.updateProfile = function (arg) {
+  return new Promise(function (resolve, reject) {
+    try {
+      var onCompletion = function (error) {
+        if (error) {
+          reject(error.localizedDescription);
+        } else {
+          resolve();
+        }
+      };
+
+      var fAuth = FIRAuth.auth();
+      if (fAuth === null) {
+        reject("Run init() first!");
+        return;
+      }
+
+      if (!arg.displayName && !arg.photoURL) {
+        reject("Updating a profile requires a displayName and / or a photoURL argument");
+      } else {
+        var user = fAuth.currentUser;
+        if (user) {
+          var changeRequest = user.profileChangeRequest();
+          changeRequest.displayName = arg.displayName;
+          changeRequest.photoURL = NSURL.URLWithString(arg.photoURL);
+          changeRequest.commitChangesWithCompletion(onCompletion);
+        } else {
+          reject();
+        }
+      }
+    } catch (ex) {
+      console.log("Error in firebase.updateProfile: " + ex);
+      reject(ex);
+    }
+  });
+};
+
 firebase._addObservers = function(to, updateCallback) {
   var listeners = [];
   listeners.push(to.observeEventTypeWithBlock(FIRDataEventType.FIRDataEventTypeChildAdded, function (snapshot) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -237,6 +237,14 @@ export interface CreateUserOptions {
 }
 
 /**
+ * The options object passed into the updateProfile function.
+ */
+export interface UpdateProfileOptions {
+    displayName: string;
+    photoURL: string;
+}
+
+/**
  * The options object passed into the resetPassword function.
  */
 export interface ResetPasswordOptions {
@@ -521,6 +529,8 @@ export function sendEmailVerification(): Promise<any>;
 export function createUser(options: CreateUserOptions): Promise<CreateUserResult>;
 
 export function deleteUser(): Promise<any>;
+
+export function updateProfile(options: UpdateProfileOptions): Promise<any>;
 
 export function resetPassword(options: ResetPasswordOptions): Promise<any>;
 


### PR DESCRIPTION
Hi,

The `updateProfile` method was missing, which was needed for updating the user-properties called  `displayName` and `profileURL`. I have implemented this method for both iOS and Android. And I have also verified that this method works on both platforms.

Please note, that in the latest version of Firebase Android SDK (9.8), a bug was introduced which causes displayName and photoUrl to always be null when fetched through `getCurrentUser()`:

https://github.com/firebase/FirebaseUI-Android/issues/409

/Ayhan