### PR TITLE
On login failed, show google account modal again

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -800,6 +800,10 @@ firebase.login = function (arg) {
           }
           if (!task.isSuccessful()) {
             console.log("Logging in the user failed. " + (task.getException() && task.getException().getReason ? task.getException().getReason() : task.getException()));
+            // also disconnect from Google otherwise ppl can't connect with a different account
+            if (firebase._mGoogleApiClient) {
+                com.google.android.gms.auth.api.Auth.GoogleSignInApi.revokeAccess(firebase._mGoogleApiClient);
+            }
             reject("Logging in the user failed. " + (task.getException() && task.getException().getReason ? task.getException().getReason() : task.getException()));
           } else {
             var user = task.getResult().getUser();

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -901,6 +901,10 @@ firebase.login = function (arg) {
     try {
       var onCompletion = function(user, error) {
         if (error) {
+          // also disconnect from Google otherwise ppl can't connect with a different account
+          if (typeof(GIDSignIn) !== "undefined") {
+              GIDSignIn.sharedInstance().disconnect();
+          }
           reject(error.localizedDescription);
         } else {
           resolve(toLoginResult(user));


### PR DESCRIPTION
Refer to #226 .
If the user sign in with an anonymous account and tried to link it to a already used google account, he got stuck in a loop, where he wasn't able to choose a different account. Fixed that.