### PR TITLE
Fix to return downloadUrl in response of uploadFile for iOS

### DIFF
--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -1540,7 +1540,7 @@ firebase.uploadFile = function (arg) {
         } else {
           resolve({
             name: metadata.name,
-            url: metadata.downloadURL.absoluteString,
+            url: metadata.downloadURL() ? metadata.downloadURL().absoluteString : null,
             contentType: metadata.contentType,
             created: metadata.timeCreated,
             updated: metadata.updated,


### PR DESCRIPTION
I found that in iOS, when we upload any file to storage using `firebase.uploadFile` method, in response the`url` property was not coming. 

From code of `firebase.ios.ts`, I found that currently `downloadURL` of response metadata is considered as property, but actually it is a function as mentioned at https://firebase.google.com/docs/reference/ios/firebasestorage/api/reference/Classes/FIRStorageMetadata#/c:objc(cs)FIRStorageMetadata(im)downloadURL

Just changing `downloadURL` to function call, it resolves this issue.

Let me know in case of any concerns and thanks for this very useful plugin 👍 