### PR TITLE
Use Gson to convert javaObject to jsObject

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -14,6 +14,8 @@ firebase._facebookAccessToken = null;
 var fbCallbackManager = null;
 var GOOGLE_SIGNIN_INTENT_ID = 123;
 
+var gson = new com.google.gson.Gson();
+
 (function() {
   if (typeof(com.google.firebase.messaging) === "undefined") {
     return;
@@ -107,35 +109,7 @@ firebase.toValue = function(val){
 };
 
 firebase.toJsObject = function(javaObj) {
-  if (javaObj === null || typeof javaObj != "object") {
-    return javaObj;
-  }
-
-  var node;
-  switch (javaObj.getClass().getName()) {
-    case 'java.lang.Boolean':
-      var str = String(javaObj);
-      return Boolean(!!(str == "True" || str == "true"));
-    case 'java.lang.String':
-      return String(javaObj);
-    case 'java.lang.Long':
-    case 'java.lang.Double':
-      return Number(String(javaObj));
-    case 'java.util.ArrayList':
-      node = [];
-      for (var i = 0; i < javaObj.size(); i++) {
-        node[i] = firebase.toJsObject(javaObj.get(i));
-      }
-      break;
-    default:
-      node = {};
-      var iterator = javaObj.entrySet().iterator();
-      while (iterator.hasNext()) {
-        var item = iterator.next();
-        node[item.getKey()] = firebase.toJsObject(item.getValue());
-      }
-  }
-  return node;
+  return JSON.parse(gson.toJson(javaObj));
 };
 
 firebase.getCallbackData = function(type, snapshot) {
@@ -1401,9 +1375,10 @@ firebase.query = function (updateCallback, path, options) {
       if (options.singleEvent) {
         var listener = new com.google.firebase.database.ValueEventListener({
           onDataChange: function (snapshot) {
-            updateCallback(firebase.getCallbackData('ValueChanged', snapshot));
+            var data = firebase.getCallbackData('ValueChanged', snapshot);
+            updateCallback(data);
             // resolve promise with data in case of single event, see https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/126
-            resolve(firebase.getCallbackData('ValueChanged', snapshot));
+            resolve(data);
           },
           onCancelled: function (databaseError) {
             updateCallback({

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile "com.google.firebase:firebase-auth:10.2.+"
 
     // for converting Java objects to JS
-    compile 'com.google.code.gson:gson:2.8.+'
+    compile "com.google.code.gson:gson:2.8.+"
 
     // for reading google-services.json and configuration
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '10.2.+'

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -18,6 +18,9 @@ dependencies {
     compile "com.google.firebase:firebase-database:10.2.+"
     compile "com.google.firebase:firebase-auth:10.2.+"
 
+    // for converting Java objects to JS
+    compile 'com.google.code.gson:gson:2.8.+'
+
     // for reading google-services.json and configuration
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '10.2.+'
     compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"

--- a/scripts/installer.js
+++ b/scripts/installer.js
@@ -269,6 +269,9 @@ dependencies {
     compile "com.google.firebase:firebase-database:10.2.+"
     compile "com.google.firebase:firebase-auth:10.2.+"
 
+    // for converting Java objects to JS
+    compile "com.google.code.gson:gson:2.8.+"
+    
     // for reading google-services.json and configuration
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '10.2.+'
     compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"


### PR DESCRIPTION
Hi,

We had major performance issues with the plugin when working with medium json files (>50K). It took a couple of seconds (5-8 seconds) to convert the javaObject to javascript one, and it was done twice instead of just one time.

Using Gson (any other library will due I guees) with JSON.parse it take only several (200-300) milliseconds.

This has not tested fully yet and maybe it should be configurable (maybe its having a performance issue on a small size files).

Would like to know why in the first place the conversion was done this way and not with some standard library.

Shay