### PR TITLE
Return Facebook access token to login result for use with FB SDK

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -256,6 +256,18 @@ Then add the following lines to your code and check for setup instructions for y
 
 For a complete list of the available scope permissions, visit Facebook's documentation: https://developers.facebook.com/docs/facebook-login/permissions. 
 
+#### Post-login Graph API querying
+Upon successful authentication, Facebook creates an access token that can be obtained from the login method's result object. This access token can then be used for querying the Facebook Graph API, by feeding it to either Facebook's Javascript SDK or their iOS/Android native SDKs:
+
+```js
+"providers": [
+         {
+             "id": "facebook.com",
+             "token": "<FB token>"
+         }
+     ]
+```
+
 #### iOS
  1. If you didn't choose this feature during installation you can open the `Podfile` in the plugin's `platforms/ios` folder and uncomment the Facebook line.
  2. Add a bit of config to `app\App_Resources\iOS\Info.plist` as instructed in Step 4 [here](https://developers.facebook.com/docs/ios/getting-started).

--- a/firebase.android.js
+++ b/firebase.android.js
@@ -777,9 +777,8 @@ function toLoginResult(user) {
   var providerData = user.getProviderData();
   for (var i = 0; i < providerData.size(); i++) {
     var pid = providerData.get(i).getProviderId();
-    providers.push({
-      id: pid
-    });
+    if (pid==='facebook.com') { providers.push({ id: pid, token: firebase._facebookAccessToken }); }
+    else { providers.push({ id: pid }); }
   }
 
   return {

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -856,9 +856,8 @@ function toLoginResult(user) {
   for (i = 0, l = user.providerData.count; i < l; i++) {
     var firUserInfo = user.providerData.objectAtIndex(i);
     var pid = firUserInfo.valueForKey("providerID");
-    providers.push({
-      id: pid
-    });
+    if (pid==='facebook.com') { providers.push({ id: pid, token: FBSDKAccessToken.currentAccessToken().tokenString }); }
+    else { providers.push({ id: pid }); }
   }
 
   return {


### PR DESCRIPTION
Return the Facebook access token to the login result, so that the developer can use it for querying the FB Graph API.

It seems to work on a Samsung Galaxy 4 Android device and the iOS simulator.