### PR TITLE
Fix hanging CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,11 @@
   },
   "homepage": "https://github.com/eddyverbruggen/nativescript-plugin-firebase",
   "dependencies": {
-    "xcode": "0.9.2",
-    "prompt-lite": "^0.1.1",
+    "fs-extra": "2.1.2",
     "fs-promise": "^2.0.0",
-    "nativescript-hook": "^0.2.1"
+    "nativescript-hook": "^0.2.1",
+    "prompt-lite": "^0.1.1",
+    "xcode": "0.9.2"
   },
   "devDependencies": {
     "prompt-lite": "^0.1.1",

--- a/scripts/installer.js
+++ b/scripts/installer.js
@@ -34,6 +34,9 @@ function readConfig() {
         config = {};
     }
 }
+function isInteractive() {
+    return process.stdin && process.stdin.isTTY && process.stdout && process.stdout.isTTY;
+}
 
 // workaround for https://github.com/NativeScript/nativescript-cli/issues/2521 (2.5.0 only)
 var nativeScriptVersion = "";
@@ -62,6 +65,8 @@ if (process.argv.indexOf("config") === -1 && fs.existsSync(pluginConfigPath)) {
     console.log("***** in the node_modules/nativescript-plugin-firebase folder *****");
     console.log("*******************************************************************");
     console.log("*******************************************************************");
+} else if (!isInteractive()) {
+    console.log("No existing " + pluginConfigFile + " config file found and terminal is not interactive! Default configuration will be used.");
 } else {
     console.log("No existing " + pluginConfigFile + " config file found, so let's configure the Firebase plugin!");
     prompt.start();
@@ -271,7 +276,7 @@ dependencies {
 
     // for converting Java objects to JS
     compile "com.google.code.gson:gson:2.8.+"
-    
+
     // for reading google-services.json and configuration
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '10.2.+'
     compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
@@ -356,7 +361,7 @@ var fs = require("fs");
 module.exports = function() {
 
     console.log("Configure firebase");
-    var buildGradlePath = path.join(__dirname, "..", "..", "platforms", "android", "build.gradle"); 
+    var buildGradlePath = path.join(__dirname, "..", "..", "platforms", "android", "build.gradle");
     if (fs.existsSync(buildGradlePath)) {
         var buildGradleContent = fs.readFileSync(buildGradlePath).toString();
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2832,6 +2832,9 @@ function readConfig() {
         config = {};
     }
 }
+function isInteractive() {
+    return process.stdin && process.stdin.isTTY && process.stdout && process.stdout.isTTY;
+}
 
 // workaround for https://github.com/NativeScript/nativescript-cli/issues/2521 (2.5.0 only)
 var nativeScriptVersion = "";
@@ -2860,6 +2863,8 @@ if (process.argv.indexOf("config") === -1 && fs.existsSync(pluginConfigPath)) {
     console.log("***** in the node_modules/nativescript-plugin-firebase folder *****");
     console.log("*******************************************************************");
     console.log("*******************************************************************");
+} else if (!isInteractive()) {
+    console.log("No existing " + pluginConfigFile + " config file found and terminal is not interactive! Default configuration will be used.");
 } else {
     console.log("No existing " + pluginConfigFile + " config file found, so let's configure the Firebase plugin!");
     prompt.start();
@@ -3069,7 +3074,7 @@ dependencies {
 
     // for converting Java objects to JS
     compile "com.google.code.gson:gson:2.8.+"
-    
+
     // for reading google-services.json and configuration
     def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : '10.2.+'
     compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
@@ -3154,7 +3159,7 @@ var fs = require("fs");
 module.exports = function() {
 
     console.log("Configure firebase");
-    var buildGradlePath = path.join(__dirname, "..", "..", "platforms", "android", "build.gradle"); 
+    var buildGradlePath = path.join(__dirname, "..", "..", "platforms", "android", "build.gradle");
     if (fs.existsSync(buildGradlePath)) {
         var buildGradleContent = fs.readFileSync(buildGradlePath).toString();
 


### PR DESCRIPTION
### Fix usage of plugin with npm 2
Whenever you try using the plugin with `npm 2`, it's postinstall script will fail, as it requires `fs-extra` module. However it's not been added as dependency of the plugin, so it does not exist in node_modules and `require` fails.
When npm 3 or later is used, the `fs-extra` plugin exists in the root level of `node_modules` as it is a dependency of `fs-promise`. npm 3 and later tries to flatten the dependencies tree, so `fs-extra` is moved in the root level and the `require` in the post-install script works.

In order to fix this, add the `fs-extra` as dependency of the plugin.

> NOTE: Maybe it's worth checking why we need `fs-extra`, Node.js `fs` could do the work, but I leave it for further discussions.


### Fix postinstall in CI environment
In case you are in CI environment (non-interactive terminal), the postinstall script will fail as it prompts for action (in case there's no firebase.nativescript.json). As this is one of the basic scenarios when adding a plugin (add it and try building the project), some CI or cloud builds are hanging.
So add a check if the console is interactive and use the default settings in case it is.