### PR TITLE
[iOS] Fix firebaseAuth reference error

### DIFF
--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -1082,7 +1082,7 @@ firebase.login = function (arg) {
           arg.customOptions.tokenProviderFn()
               .then(
                   function (token) {
-                    firebaseAuth.signInWithCustomTokenCompletion(token, onCompletion);
+                    fAuth.signInWithCustomTokenCompletion(token, onCompletion);
                   },
                   function (error) {
                     reject(error);


### PR DESCRIPTION
Fixes fireBaseAuth reference error when using custom token provider function on iOS.