### PR TITLE
Skip linking for anonymous users

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -1142,6 +1142,10 @@ firebase.login = function (arg) {
 };
 
 firebase._alreadyLinkedToAuthProvider = function (user, providerId) {
+  if (user.isAnonymous()) {
+    return true;
+  }
+
   var providerData = user.getProviderData();
   for (var i = 0; i < providerData.size(); i++) {
     var profile = providerData.get(i);


### PR DESCRIPTION
Should fix #357 and #389 and maybe others as well.

This will avoid the exception `com.google.firebase.auth.FirebaseAuthUserCollisionException: This credential is already associated with a different user account`.

This issue occurs if you call `user.linkWithCredential` on a anonymous user, but the `authCredential` points to another already known firebase user (e.g a facebook account). Instead `firebaseAuth.signInWithCredential` will be called.