### PR TITLE
Moved AdMob init to firebase.init, added AdListener to showBanner()

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -208,9 +208,6 @@ firebase.init = function (arg) {
 
       var firebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
 
-      // init admob
-      com.google.android.gms.ads.MobileAds.initialize(appModule.android.context); // TODO not sure its bound to packagename.. this is from the admob-demo
-
       if (arg.onAuthStateChanged) {
         firebase.authStateListener = new com.google.firebase.auth.FirebaseAuth.AuthStateListener({
           onAuthStateChanged: function (fbAuth) {
@@ -268,6 +265,12 @@ firebase.init = function (arg) {
         });
       }
 
+      // Firebase AdMob
+      if (typeof(com.google.android.gms.ads) !== "undefined") {
+        // init admob
+        com.google.android.gms.ads.MobileAds.initialize(appModule.android.context); 
+      }
+        
       resolve(firebase.instance);
     }
 
@@ -545,38 +548,38 @@ firebase.admob.showBanner = function (arg) {
 };
 
 firebase.admob.showInterstitial = function (arg) {
-  return new Promise(function (resolve, reject) {
-    try {
-      var settings = firebase.merge(arg, firebase.admob.defaults);
-      firebase.admob.interstitialView = new com.google.android.gms.ads.InterstitialAd(appModule.android.foregroundActivity);
-      firebase.admob.interstitialView.setAdUnitId(settings.androidInterstitialId);
-
-      // Interstitial ads must be loaded before they can be shown, so adding a listener
-      var InterstitialAdListener = com.google.android.gms.ads.AdListener.extend({
-        onAdLoaded: function () {
-          firebase.admob.interstitialView.show();
-          resolve();
-        },
-        onAdFailedToLoad: function (errorCode) {
-          reject(errorCode);
-        },
-        onAdClosed: function () {
-          firebase.admob.interstitialView.setAdListener(null);
-          firebase.admob.interstitialView = null;
-        }
-      });
-      firebase.admob.interstitialView.setAdListener(new InterstitialAdListener());
-
-      var ad = firebase.admob._buildAdRequest(settings);
-      firebase.admob.interstitialView.loadAd(ad);
-    } catch (ex) {
-      console.log("Error in firebase.admob.showInterstitial: " + ex);
-      reject(ex);
-    }
-  });
-};
-
-firebase.admob.hideBanner = function (arg) {
+    return new Promise(function (resolve, reject) {
+      try {
+        var settings = firebase.merge(arg, firebase.admob.defaults);
+        firebase.admob.interstitialView = new com.google.android.gms.ads.InterstitialAd(appModule.android.foregroundActivity);
+        firebase.admob.interstitialView.setAdUnitId(settings.androidInterstitialId);
+  
+        // Interstitial ads must be loaded before they can be shown, so adding a listener
+        var InterstitialAdListener = com.google.android.gms.ads.AdListener.extend({
+          onAdLoaded: function () {
+            firebase.admob.interstitialView.show();
+            resolve();
+          },
+          onAdFailedToLoad: function (errorCode) {
+            reject(errorCode);
+          },
+          onAdClosed: function () {
+            firebase.admob.interstitialView.setAdListener(null);
+            firebase.admob.interstitialView = null;
+          }
+        });
+        firebase.admob.interstitialView.setAdListener(new InterstitialAdListener());
+  
+        var ad = firebase.admob._buildAdRequest(settings);
+        firebase.admob.interstitialView.loadAd(ad);
+      } catch (ex) {
+        console.log("Error in firebase.admob.showInterstitial: " + ex);
+        reject(ex);
+      }
+    });
+  };
+  
+  firebase.admob.hideBanner = function (arg) {
   return new Promise(function (resolve, reject) {
     try {
       if (firebase.admob.adView !== null) {

--- a/firebase.d.ts
+++ b/firebase.d.ts
@@ -568,6 +568,16 @@ export module admob {
     LEADERBOARD
   }
 
+  /**
+   * The possible error codes (see https://developers.google.com/android/reference/com/google/android/gms/ads/AdRequest#ERROR_CODE_INTERNAL_ERROR).
+   */
+  export enum ERROR_CODES {
+    ERROR_CODE_INTERNAL_ERROR,
+    ERROR_CODE_INVALID_REQUEST,
+    ERROR_CODE_NETWORK_ERROR,
+    ERROR_CODE_NO_FILL
+  }
+
   export interface ShowBannerOptions {
     /**
      * The layout of the banner.


### PR DESCRIPTION
The initialization of the AdMob plugin takes some time with current plugin-implementation. Showing the first banner could be delayed by a few seconds. Moving AdMob init from `firebase.admob.showBanner()` to `firebase.init` speeds that up a lot.

I've also added an `AdListener` to `firebase.admob.showBanner()`, similar to the one already used in `firebase.admob.showInterstitial()`. With that we can take care when a banner isn't displayed because of an network error or something else. The current implementation didn't return those kind of errors.