### PR TITLE
Added null check for updateCallback on query

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -1677,12 +1677,12 @@ firebase.query = function (updateCallback, path, options) {
         var listener = new com.google.firebase.database.ValueEventListener({
           onDataChange: function (snapshot) {
             var data = firebase.getCallbackData('ValueChanged', snapshot);
-            updateCallback(data);
+            if(updateCallback) updateCallback(data);
             // resolve promise with data in case of single event, see https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/126
             resolve(data);
           },
           onCancelled: function (databaseError) {
-            updateCallback({
+            if(updateCallback) updateCallback({
               error: databaseError.getMessage()
             });
             // see comment at 'onDataChange'

--- a/firebase.ios.js
+++ b/firebase.ios.js
@@ -1728,7 +1728,7 @@ firebase.query = function (updateCallback, path, options) {
 
       if (options.singleEvent) {
         query.observeSingleEventOfTypeWithBlock(FIRDataEventType.FIRDataEventTypeValue, function (snapshot) {
-          updateCallback(firebase.getCallbackData('ValueChanged', snapshot));
+          if(updateCallback) updateCallback(firebase.getCallbackData('ValueChanged', snapshot));
           // resolve promise with data in case of single event, see https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/126
           resolve(firebase.getCallbackData('ValueChanged', snapshot));
         });


### PR DESCRIPTION
When using the singleEvent option on a query, there are quite a few cases where we need to retrieve the data via the promise. In some of those cases, it does not make sense to also implement a callback, so a null check allows us to just pass null instead of a stub callback.