### PR TITLE
Improved Promise handling for showInterstitial()

### DIFF
--- a/firebase.android.js
+++ b/firebase.android.js
@@ -600,7 +600,6 @@ firebase.admob.showInterstitial = function (arg) {
       var InterstitialAdListener = com.google.android.gms.ads.AdListener.extend({
         onAdLoaded: function () {
           firebase.admob.interstitialView.show();
-          resolve();
         },
         onAdFailedToLoad: function (errorCode) {
           reject(errorCode);
@@ -608,6 +607,7 @@ firebase.admob.showInterstitial = function (arg) {
         onAdClosed: function () {
           firebase.admob.interstitialView.setAdListener(null);
           firebase.admob.interstitialView = null;
+          resolve();
         }
       });
       firebase.admob.interstitialView.setAdListener(new InterstitialAdListener());


### PR DESCRIPTION
Let showInterstitial() fullfil promise when the ad is closed instead of when the ad is loaded.

This way we can detect when the ad is closed and perform following actions. Before we only knew the ad was loaded, but we didn't knew if the user closed the ad already.