### PR TITLE
Update Firebase to 4.3.0 to fix background notifications on iOS

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,5 +1,5 @@
 
-pod 'Firebase', '~> 4.1.1'
+pod 'Firebase', '~> 4.3.0'
 pod 'Firebase/Database'
 pod 'Firebase/Auth'
 


### PR DESCRIPTION
The version `4.3.0` of Firebase has an important issue solved described below:

> - Resolved issues with FCM token associations to APNs device tokens.

This issue generate a problem with background notifications on iOS (The notification banner doesn't appear).