### PR TITLE
(fix): Firebase pod 4.4.0 is now used

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,5 +1,5 @@
 
-pod 'Firebase', '~> 4.3.0'
+pod 'Firebase', '~> 4.4.0'
 pod 'Firebase/Database'
 pod 'Firebase/Auth'
 

--- a/scripts/installer.js
+++ b/scripts/installer.js
@@ -215,7 +215,7 @@ function writePodFile(result) {
     }
     try {
         fs.writeFileSync(directories.ios + '/Podfile',
-`pod 'Firebase', '~> 4.1.1'
+`pod 'Firebase', '~> 4.4.0'
 pod 'Firebase/Database'
 pod 'Firebase/Auth'
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3013,7 +3013,7 @@ function writePodFile(result) {
     }
     try {
         fs.writeFileSync(directories.ios + '/Podfile',
-`pod 'Firebase', '~> 4.1.1'
+`pod 'Firebase', '~> 4.4.0'
 pod 'Firebase/Database'
 pod 'Firebase/Auth'
 


### PR DESCRIPTION
Even though the pod file was changed to use the latest version, the Firebase pod version was reverted back to `4.1.1` after the install script ran. Now the correct pod version will be used.