### PR TITLE
Implement setUserId for analytics

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -550,6 +550,24 @@ firebase.analytics.logEvent = arg => {
   });
 };
 
+firebase.analytics.setUserId = arg => {
+  return new Promise((resolve, reject) => {
+    try {
+      if (arg.userId === undefined) {
+        reject("Argument 'userId' is missing");
+        return;
+      }
+
+      com.google.firebase.analytics.FirebaseAnalytics.getInstance(appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()).setUserId(arg.userId);
+
+      resolve();
+    } catch (ex) {
+      console.log("Error in firebase.analytics.setUserId: " + ex);
+      reject(ex);
+    }
+  });
+};
+
 firebase.analytics.setUserProperty = arg => {
   return new Promise((resolve, reject) => {
     try {

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -694,6 +694,10 @@ export namespace analytics {
     parameters?: Array<LogEventParameter>;
   }
 
+  export interface SetUserIdOptions {
+    userId: string;
+  }
+
   export interface SetUserPropertyOptions {
     key: string;
     value: string;
@@ -705,6 +709,8 @@ export namespace analytics {
 
   function logEvent(options: LogEventOptions): Promise<any>;
 
+  function setUserId(options: SetUserIdOptions): Promise<any>;
+  
   function setUserProperty(options: SetUserPropertyOptions): Promise<any>;
 
   function setScreenName(options: SetScreenNameOptions): Promise<any>;

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -750,6 +750,24 @@ firebase.analytics.logEvent = arg => {
   });
 };
 
+firebase.analytics.setUserId = arg => {
+  return new Promise((resolve, reject) => {
+    try {
+      if (arg.userId === undefined) {
+        reject("Argument 'userId' is missing");
+        return;
+      }
+
+      FIRAnalytics.setUserID(arg.userId);
+
+      resolve();
+    } catch (ex) {
+      console.log("Error in firebase.analytics.setUserId: " + ex);
+      reject(ex);
+    }
+  });
+};
+
 firebase.analytics.setUserProperty = arg => {
   return new Promise((resolve, reject) => {
     try {


### PR DESCRIPTION
This adds a "setUserId" method which actually calls https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.html#setUserId(java.lang.String) for Android and https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#setuserid for IOS