### PR TITLE
fix snapshot creation logic and data callback return type

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -2314,7 +2314,7 @@ firebase.firestore.onDocumentSnapshot = (docRef: com.google.firebase.firestore.D
           callback(new DocumentSnapshot(
               snapshot ? snapshot.getId() : null,
               snapshot.exists(),
-              snapshot ? () => firebase.toJsObject(snapshot.getData()) : null));
+              () => snapshot.exists() ? firebase.toJsObject(snapshot.getData()) : undefined));
         })
       })
   );

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -2268,7 +2268,10 @@ firebase.firestore.collection = (collectionPath: string): firestore.CollectionRe
 
 firebase.firestore.onDocumentSnapshot = (docRef: FIRDocumentReference, callback: (doc: DocumentSnapshot) => void): () => void => {
   const listener = docRef.addSnapshotListener((snapshot: FIRDocumentSnapshot, error: NSError) => {
-    callback(new DocumentSnapshot(snapshot ? snapshot.documentID : null, !!snapshot, snapshot ? () => firebase.toJsObject(snapshot.data()) : null));
+    callback(new DocumentSnapshot(
+      snapshot ? snapshot.documentID : null,
+      snapshot.exists,
+      () => snapshot.exists ? firebase.toJsObject(snapshot.data()) : undefined));
   });
 
   // There's a bug resulting this function to be undefined..


### PR DESCRIPTION
Addresses #661 

Note that this brings the plugin API in line with the web API which could cause breaking changes for those using checks like `DocumentSnapshot.data === null`. If you want to use checks like that, you should use `DocumentSnapshot.data() === undefined` now.