### PR TITLE
use googlePlayServicesVersion instead of firebase version

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -461,6 +461,7 @@ repositories {
 }
 
 def supportVersion = project.hasProperty("supportVersion") ? project.supportVersion : "26.0.0"
+def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "12.0.1"
 
 dependencies {
     compile "com.android.support:appcompat-v7:$supportVersion"
@@ -469,39 +470,37 @@ dependencies {
     compile "com.android.support:design:$supportVersion"
     compile "com.android.support:support-compat:$supportVersion"
 
-    def firebaseVersion = "12.0.1"
 
     // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
-    compile "com.google.firebase:firebase-core:$firebaseVersion"
-    compile "com.google.firebase:firebase-auth:$firebaseVersion"
+    compile "com.google.firebase:firebase-core:$googlePlayServicesVersion"
+    compile "com.google.firebase:firebase-auth:$googlePlayServicesVersion"
 
     // for reading google-services.json and configuration
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : firebaseVersion
     compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
 
     // Uncomment if you want to use the regular Database
-    ` + (!isPresent(result.realtimedb) || isSelected(result.realtimedb) ? `` : `//`) + ` compile "com.google.firebase:firebase-database:$firebaseVersion"
+    ` + (!isPresent(result.realtimedb) || isSelected(result.realtimedb) ? `` : `//`) + ` compile "com.google.firebase:firebase-database:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Cloud Firestore'
-    ` + (isSelected(result.firestore) ? `` : `//`) + ` compile "com.google.firebase:firebase-firestore:$firebaseVersion"
+    ` + (isSelected(result.firestore) ? `` : `//`) + ` compile "com.google.firebase:firebase-firestore:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Remote Config'
-    ` + (isSelected(result.remote_config) ? `` : `//`) + ` compile "com.google.firebase:firebase-config:$firebaseVersion"
+    ` + (isSelected(result.remote_config) ? `` : `//`) + ` compile "com.google.firebase:firebase-config:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Crash Reporting'
-    ` + (isSelected(result.crash_reporting) && !isSelected(result.crashlytics) ? `` : `//`) + ` compile "com.google.firebase:firebase-crash:$firebaseVersion"
+    ` + (isSelected(result.crash_reporting) && !isSelected(result.crashlytics) ? `` : `//`) + ` compile "com.google.firebase:firebase-crash:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Crashlytics'
     ` + (isSelected(result.crashlytics) ? `` : `//`) + ` compile "com.crashlytics.sdk.android:crashlytics:2.9.1"
 
     // Uncomment if you want FCM (Firebase Cloud Messaging)
-    ` + (isSelected(result.messaging) ? `` : `//`) + ` compile "com.google.firebase:firebase-messaging:$firebaseVersion"
+    ` + (isSelected(result.messaging) ? `` : `//`) + ` compile "com.google.firebase:firebase-messaging:$googlePlayServicesVersion"
 
     // Uncomment if you want Google Cloud Storage
-    ` + (isSelected(result.storage) ? `` : `//`) + ` compile "com.google.firebase:firebase-storage:$firebaseVersion"
+    ` + (isSelected(result.storage) ? `` : `//`) + ` compile "com.google.firebase:firebase-storage:$googlePlayServicesVersion"
 
     // Uncomment if you want AdMob
-    ` + (isSelected(result.admob) ? `` : `//`) + ` compile "com.google.firebase:firebase-ads:$firebaseVersion"
+    ` + (isSelected(result.admob) ? `` : `//`) + ` compile "com.google.firebase:firebase-ads:$googlePlayServicesVersion"
 
     // Uncomment if you need Facebook Authentication
     ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` compile ("com.facebook.android:facebook-android-sdk:4.+"){ exclude group: 'com.google.zxing' }
@@ -510,7 +509,7 @@ dependencies {
     ` + (isSelected(result.google_auth) ? `` : `//`) + ` compile "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
 
     // Uncomment if you need Firebase Invites or Dynamic Links
-    ` + (isSelected(result.invites) ? `` : `//`) + ` compile "com.google.firebase:firebase-invites:$firebaseVersion"
+    ` + (isSelected(result.invites) ? `` : `//`) + ` compile "com.google.firebase:firebase-invites:$googlePlayServicesVersion"
 }
 
 apply plugin: "com.google.gms.google-services"

--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -463,6 +463,10 @@ repositories {
 def supportVersion = project.hasProperty("supportVersion") ? project.supportVersion : "26.0.0"
 def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "12.0.1"
 
+if ( VersionNumber.parse( googlePlayServicesVersion ) < VersionNumber.parse( '9.2' ) ) {
+    throw new GradleException('Google Play services version too low, please update to at least 9.2');
+}
+
 dependencies {
     compile "com.android.support:appcompat-v7:$supportVersion"
     compile "com.android.support:cardview-v7:$supportVersion"
@@ -470,6 +474,7 @@ dependencies {
     compile "com.android.support:design:$supportVersion"
     compile "com.android.support:support-compat:$supportVersion"
 
+  
 
     // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
     compile "com.google.firebase:firebase-core:$googlePlayServicesVersion"

--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -463,9 +463,15 @@ repositories {
 def supportVersion = project.hasProperty("supportVersion") ? project.supportVersion : "26.0.0"
 def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "12.0.1"
 
-if ( VersionNumber.parse( googlePlayServicesVersion ) < VersionNumber.parse( '9.2' ) ) {
-    throw new GradleException('Google Play services version too low, please update to at least 9.2');
+` + (isSelected(result.firestore) ? `
+if ( VersionNumber.parse( googlePlayServicesVersion ) < VersionNumber.parse( '11.4.2' ) ) {
+    throw new GradleException(" googlePlayServicesVersion set too low, as you want to use firestore please update to at least 11.4.2 ( currently set to $googlePlayServicesVersion )");
 }
+` : `
+if ( VersionNumber.parse( googlePlayServicesVersion ) < VersionNumber.parse( '9.2' ) ) {
+    throw new GradleException("googlePlayServicesVersion set too low, please update to at least '9.2' ( currently set to $googlePlayServicesVersion )");
+}
+`) + `
 
 dependencies {
     compile "com.android.support:appcompat-v7:$supportVersion"
@@ -473,8 +479,6 @@ dependencies {
     compile "com.android.support:customtabs:$supportVersion"
     compile "com.android.support:design:$supportVersion"
     compile "com.android.support:support-compat:$supportVersion"
-
-  
 
     // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
     compile "com.google.firebase:firebase-core:$googlePlayServicesVersion"

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -16,6 +16,7 @@ repositories {
 }
 
 def supportVersion = project.hasProperty("supportVersion") ? project.supportVersion : "26.0.0"
+def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "12.0.1"
 
 dependencies {
     compile "com.android.support:appcompat-v7:$supportVersion"
@@ -24,39 +25,36 @@ dependencies {
     compile "com.android.support:design:$supportVersion"
     compile "com.android.support:support-compat:$supportVersion"
 
-    def firebaseVersion = "12.0.1"
-
     // make sure you have these versions by updating your local Android SDK's (Android Support repo and Google repo)
-    compile "com.google.firebase:firebase-core:$firebaseVersion"
-    compile "com.google.firebase:firebase-auth:$firebaseVersion"
+    compile "com.google.firebase:firebase-core:$googlePlayServicesVersion"
+    compile "com.google.firebase:firebase-auth:$googlePlayServicesVersion"
 
     // for reading google-services.json and configuration
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : firebaseVersion
     compile "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
 
     // Uncomment if you want to use the regular Database (instead of 'Cloud Firestore')
-//    compile "com.google.firebase:firebase-database:$firebaseVersion"
+//    compile "com.google.firebase:firebase-database:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Cloud Firestore'
-//    compile "com.google.firebase:firebase-firestore:$firebaseVersion"
+//    compile "com.google.firebase:firebase-firestore:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Remote Config'
-//    compile "com.google.firebase:firebase-config:$firebaseVersion"
+//    compile "com.google.firebase:firebase-config:$googlePlayServicesVersion"
 
     // Uncomment if you want to use 'Crash Reporting'
-//    compile "com.google.firebase:firebase-crash:$firebaseVersion"
+//    compile "com.google.firebase:firebase-crash:$googlePlayServicesVersion"
 
     // Uncomment if you want to enable 'Crashlytics' (1 / 2)
 //    compile 'com.crashlytics.sdk.android:crashlytics:2.9.1'
 
     // Uncomment if you want FCM (Firebase Cloud Messaging)
-//    compile "com.google.firebase:firebase-messaging:$firebaseVersion"
+//    compile "com.google.firebase:firebase-messaging:$googlePlayServicesVersion"
 
     // Uncomment if you want Google Cloud Storage
-//    compile "com.google.firebase:firebase-storage:$firebaseVersion"
+//    compile "com.google.firebase:firebase-storage:$googlePlayServicesVersion"
 
     // Uncomment if you want AdMob
-//    compile "com.google.firebase:firebase-ads:$firebaseVersion"
+//    compile "com.google.firebase:firebase-ads:$googlePlayServicesVersion"
 
     // Uncomment if you need Facebook Authentication
 //    compile ("com.facebook.android:facebook-android-sdk:4.+"){ exclude group: 'com.google.zxing' }
@@ -65,7 +63,7 @@ dependencies {
 //    compile "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
 
     // Uncomment if you need Firebase Invites or Dynamics Links
-//    compile "com.google.firebase:firebase-invites:$firebaseVersion"
+//    compile "com.google.firebase:firebase-invites:$googlePlayServicesVersion"
 }
 
 apply plugin: "com.google.gms.google-services"


### PR DESCRIPTION
Now that the firebase and google play services's versions are aligned, it avoids version conflicts with google play services. 

Possible breaking changes: 
 - Using an Old version of Google Play services where there wasnt a comparable firebase version will probably not work and will need updating. 

