### PR TITLE
expose raw barcode scan result object

### DIFF
--- a/src/mlkit/barcodescanning/index.android.ts
+++ b/src/mlkit/barcodescanning/index.android.ts
@@ -38,7 +38,8 @@ export class MLKitBarcodeScanner extends MLKitBarcodeScannerBase {
           const barcode = barcodes.get(i);
           result.barcodes.push({
             value: barcode.getRawValue(),
-            format: BarcodeFormat[barcode.getFormat()]
+            format: BarcodeFormat[barcode.getFormat()],
+            android: barcode
           });
         }
 
@@ -80,7 +81,8 @@ export function scanBarcodesOnDevice(options: MLKitScanBarcodesOnDeviceOptions):
             const barcode = barcodes.get(i);
             result.barcodes.push({
               value: barcode.getRawValue(),
-              format: BarcodeFormat[barcode.getFormat()]
+              format: BarcodeFormat[barcode.getFormat()],
+              android: barcode
             });
           }
 

--- a/src/mlkit/barcodescanning/index.d.ts
+++ b/src/mlkit/barcodescanning/index.d.ts
@@ -8,6 +8,8 @@ export interface MLKitScanBarcodesOnDeviceResult extends MLKitResult {
   barcodes: Array<{
     value: string;
     format: string;
+    ios?: any;
+    android?: any;
   }>;
 }
 

--- a/src/mlkit/barcodescanning/index.ios.ts
+++ b/src/mlkit/barcodescanning/index.ios.ts
@@ -31,7 +31,8 @@ export class MLKitBarcodeScanner extends MLKitBarcodeScannerBase {
           const barcode: FIRVisionBarcode = barcodes.objectAtIndex(i);
           result.barcodes.push({
             value: barcode.rawValue,
-            format: BarcodeFormat[barcode.format]
+            format: BarcodeFormat[barcode.format],
+            ios: barcode
           });
         }
 
@@ -77,7 +78,8 @@ export function scanBarcodesOnDevice(options: MLKitScanBarcodesOnDeviceOptions):
             const barcode: FIRVisionBarcode = barcodes.objectAtIndex(i);
             result.barcodes.push({
               value: barcode.rawValue,
-              format: BarcodeFormat[barcode.format]
+              format: BarcodeFormat[barcode.format],
+              ios: barcode
             });
           }
           resolve(result);


### PR DESCRIPTION
I figured it may be nice to expose the raw object until it's fully covered in the plugin's API. For instance I can now use this to retrieve the location of a barcode within the camera and use it to display a label on top of the actual barcode location