### PR TITLE
trigger handler when there are no results

### DIFF
--- a/src/mlkit/barcodescanning/index.android.ts
+++ b/src/mlkit/barcodescanning/index.android.ts
@@ -23,8 +23,6 @@ export class MLKitBarcodeScanner extends MLKitBarcodeScannerBase {
     return new com.google.android.gms.tasks.OnSuccessListener({
       onSuccess: barcodes => {
 
-        if (barcodes.size() === 0) return;
-
         // const imageSource = new ImageSource();
         // imageSource.setNativeSource(this.lastVisionImage.getBitmapForDebugging());
 

--- a/src/mlkit/barcodescanning/index.ios.ts
+++ b/src/mlkit/barcodescanning/index.ios.ts
@@ -22,7 +22,7 @@ export class MLKitBarcodeScanner extends MLKitBarcodeScannerBase {
       if (error !== null) {
         console.log(error.localizedDescription);
 
-      } else if (barcodes !== null && barcodes.count > 0) {
+      } else if (barcodes !== null) {
         const result = <MLKitScanBarcodesOnDeviceResult>{
           barcodes: []
         };


### PR DESCRIPTION
As I was using this plugin I found that I'd prefer if it also triggered when there are no barcodes on the screen. This looks like different behavior to nativescript-barcodescanner, but it makes sense, because this plugin yields a list, which can be empty.

In my particular case I'm trying to display labels on top of barcodes that are scanned, but because of the way the plugin works, the labels remain even when the barcodes move out of the camera (unless another barcode is visible).

Implementation wise, for the end user of the plugin it's easier to cache the last result and replicate the current behavior, than to build a timeout mechanism to build the described desired behavior.