### PR TITLE
fix(iOS): google auth issue for iOS 10 and below

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -536,6 +536,32 @@ Make sure the URL Scheme for `REVERSED_CLIENT_ID` is in `app/App_Resources/iOS/I
 	</array>
 ```
 
+*NOTE:* iOS 10 and below issue for Google Auth when opening from a modal.
+
+If you are planning to open Google Auth from a modal view you may encounter this error resulting in nothing happening (no google auth dialog) on iOS 10 and below:
+
+```
+Warning: Attempt to present <SFSafariViewController: 0x7fa575968470> on <UILayoutViewController: 0x7fa575e3d710> whose view is not in the window hierarchy!
+```
+
+To solve, you will want to pass in the appropriate iOS controller of the active view. This can be accomplished as follows:
+
+```js
+  firebase.login({
+    type: firebase.LoginType.GOOGLE,
+    ios: {
+      controller: topmost().ios.controller
+    }
+  }).then(
+      function (result) {
+        JSON.stringify(result);
+      },
+      function (errorMessage) {
+        console.log(errorMessage);
+      }
+  );
+```
+
 #### Android
 
 1. If you didn't choose this feature during installation you can uncomment `google-services-auth` in `node_modules\nativescript-plugin-firebase\platforms\android\include.gradle`

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -234,6 +234,10 @@ export interface FirebaseCustomLoginOptions {
   tokenProviderFn?: () => Promise<String>;
 }
 
+export interface LoginIOSOptions {
+  controller?: any;
+}
+
 /**
  * The options object passed into the login function.
  */
@@ -245,6 +249,7 @@ export interface LoginOptions {
   googleOptions?: FirebaseGoogleLoginOptions;
   facebookOptions?: FirebaseFacebookLoginOptions;
   customOptions?: FirebaseCustomLoginOptions;
+  ios?: LoginIOSOptions;
 
   /**
    * @deprecated Please use the 'passwordOptions?: FirebasePasswordLoginOptions' object instead.

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -1373,7 +1373,8 @@ firebase.login = arg => {
         }
 
         const sIn = GIDSignIn.sharedInstance();
-        sIn.uiDelegate = application.ios.rootController;
+        // allow custom controller for variety of use cases
+        sIn.uiDelegate = arg.ios && arg.ios.controller ? arg.ios.controller : application.ios.rootController;
         sIn.clientID = FIRApp.defaultApp().options.clientID;
 
         if (arg.googleOptions && arg.googleOptions.hostedDomain) {


### PR DESCRIPTION
*NOTE:* iOS 10 and below issue for Google Auth when initiating auth sequence from a modal view.

If you are planning to open Google Auth from a modal view you may encounter this error resulting in nothing happening (no google auth dialog) on iOS 10 and below:

> Warning: Attempt to present <SFSafariViewController: 0x7fa575968470> on <UILayoutViewController: 0x7fa575e3d710> whose view is not in the window hierarchy!

To solve, you will want to pass in the appropriate iOS controller of the active view. This can be accomplished as follows:

```js
  firebase.login({
    type: firebase.LoginType.GOOGLE,
    ios: {
      controller: topmost().ios.controller
    }
  }).then(
      function (result) {
        JSON.stringify(result);
      },
      function (errorMessage) {
        console.log(errorMessage);
      }
  );
```

Added to [auth docs here](https://github.com/EddyVerbruggen/nativescript-plugin-firebase/pull/734/files#diff-6dfb09d688d870ae6e4c537aca3d80a7R539).