### PR TITLE
fix(ui): temp fix for app becoming unresponsive due to infinite animation

### DIFF
--- a/demo-ng/app/app.css
+++ b/demo-ng/app/app.css
@@ -112,7 +112,7 @@ Label.mlkit-result {
 .swing {
   animation-name: swingAnimation;
   animation-duration: 6s;
-  animation-iteration-count: infinite;
+  animation-iteration-count: 10;
   animation-timing-function: cubic-bezier(0.42,0,1,1);
 }
 


### PR DESCRIPTION
App keeps trying to play the swing keyframe animation even when the view is destroyed, ending up in a play-catch loop.

to avoid this, animation iteration count was fixed to 10.

