### PR TITLE
Check that firebase is configured before calling FIRAuth.auth()

### DIFF
--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -57,7 +57,7 @@ function addBackgroundRemoteNotificationHandler(appDelegate) {
   if (typeof(FIRMessaging) !== "undefined") {
     appDelegate.prototype.applicationDidReceiveRemoteNotificationFetchCompletionHandler = (app, notification, completionHandler) => {
       // Pass notification to auth and check if they can handle it (in case phone auth is being used), see https://firebase.google.com/docs/auth/ios/phone-auth
-      if (FIRAuth.auth().canHandleNotification(notification)) {
+      if (firebase._configured && FIRAuth.auth().canHandleNotification(notification)) {
         completionHandler(UIBackgroundFetchResult.NoData);
         return;
       }


### PR DESCRIPTION
For my use case in EddyVerbruggen/nativescript-plugin-firebase#730, it now works correctly with this fix and I didn't notice any other issues.

But I don't think that I ever need to get into that `if` block.
@EddyVerbruggen Let me know if you think anything needs to be changed.

Closes EddyVerbruggen/nativescript-plugin-firebase#730