### PR TITLE
[iOS] Fix special fields before adding documents

### DIFF
--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -1908,7 +1908,7 @@ firebase.firestore.add = (collectionPath: string, document: any): Promise<firest
         reject("Make sure 'Firebase/Firestore' is in the plugin's Podfile");
         return;
       }
-
+      fixSpecialFields(document);
       const defaultFirestore = FIRFirestore.firestore();
       const fIRDocumentReference = defaultFirestore
           .collectionWithPath(collectionPath)


### PR DESCRIPTION
Currently the add function on Firestore skips the step where it converts specific field types to the native instances, causing incorrect data to be saved to the database.