### PR TITLE
chore: bump io.fabric.tools:gradle to 1.25.4

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -897,7 +897,7 @@ module.exports = function($logger, $projectData) {
                 let dependenciesNode = buildGradleContent.indexOf("dependencies", 0);
                 if (dependenciesNode > -1) {
                     dependenciesNode = buildGradleContent.indexOf("}", dependenciesNode);
-                    buildGradleContent = buildGradleContent.substr(0, dependenciesNode - 1) + '	    classpath "io.fabric.tools:gradle:1.25.1"\\n' + buildGradleContent.substr(dependenciesNode - 1);
+                    buildGradleContent = buildGradleContent.substr(0, dependenciesNode - 1) + '	    classpath "io.fabric.tools:gradle:1.25.4"\\n' + buildGradleContent.substr(dependenciesNode - 1);
                 }
             }
 


### PR DESCRIPTION
After we merged https://github.com/NativeScript/android-runtime/pull/1177 apps with `nativescript-plugin-firebase` fails to build for android with following error:
```
11:49:28
11:49:28
11:49:28 FAILURE: Build failed with an exception.
11:49:28
11:49:28 * What went wrong:
11:49:28 The Android Gradle plugin supports only Crashlytics Gradle plugin version 1.25.4 and higher. Project 'examples' is using version 1.25.1.
11:49:28
11:49:28 * Try:
11:49:28 Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
11:49:28
11:49:28 * Get more help at https://help.gradle.org
11:49:28
11:49:28 BUILD FAILED in 8s
11:49:28 Command ./gradlew failed with exit code 1
```

This PR bump version of io.fabric.tools:gradle to 1.25.4, which I hope will solve the problem.