### PR TITLE
feat: Added missing API

### DIFF
--- a/src/app/firestore/index.ts
+++ b/src/app/firestore/index.ts
@@ -1,9 +1,14 @@
 import * as firebase from "../../firebase";
+// import * as firebaseSdk from 'firebase/app';
 
-export module firestore {
-  export class Firestore {
+export namespace firestore {
+  export class Firestore /*implements firebaseSdk.firestore.Firestore*/ {
     collection(collectionPath: string): firebase.firestore.CollectionReference {
       return firebase.firestore.collection(collectionPath);
+    }
+
+    doc(path: string): firebase.firestore.DocumentReference {
+      return firebase.firestore.docRef(path);
     }
 
     FieldValue(): firebase.firestore.FieldValue {
@@ -13,7 +18,7 @@ export module firestore {
         serverTimestamp: () => "SERVER_TIMESTAMP",
         arrayUnion: (fields: Array<any>) => new firebase.firestore.FieldValue("ARRAY_UNION", fields),
         arrayRemove: (fields: Array<any>) => new firebase.firestore.FieldValue("ARRAY_REMOVE", fields)
-      }
+      };
     }
 
     GeoPoint(latitude: number, longitude: number): firebase.firestore.GeoPoint {

--- a/src/firebase-common.ts
+++ b/src/firebase-common.ts
@@ -8,8 +8,10 @@ import * as mlkit from "./mlkit";
 
 // note that this implementation is overridden for iOS
 export class FieldValue {
-  constructor(public type: firestore.FieldValueType, public value: any) {
-  };
+  constructor(
+    public type: firestore.FieldValueType,
+    public value: any,
+  ) { }
 
   serverTimestamp = () => "SERVER_TIMESTAMP";
   arrayUnion = (fields: Array<any>) => new FieldValue("ARRAY_UNION", fields);
@@ -204,19 +206,16 @@ export const firebase: any = {
 export abstract class DocumentSnapshot implements firestore.DocumentSnapshot {
   public data: () => firestore.DocumentData;
 
-  constructor(public id: string, public exists: boolean, documentData: firestore.DocumentData) {
+  constructor(
+    public id: string,
+    public exists: boolean,
+    documentData: firestore.DocumentData,
+    public ref: firestore.DocumentReference,
+  ) {
     this.data = () => exists ? documentData : undefined;
   }
 }
 
 export function isDocumentReference(object: any): object is firestore.DocumentReference {
   return object && object.discriminator === "docRef";
-}
-
-export class QuerySnapshot implements firestore.QuerySnapshot {
-  public docSnapshots: firestore.DocumentSnapshot[];
-
-  forEach(callback: (result: firestore.DocumentSnapshot) => void, thisArg?: any): void {
-    this.docSnapshots.map(snapshot => callback(snapshot));
-  }
 }

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -3,7 +3,6 @@ import {
   firebase,
   FieldValue,
   GeoPoint,
-  QuerySnapshot,
   isDocumentReference
 } from "./firebase-common";
 import * as firebaseMessaging from "./messaging/messaging";
@@ -14,13 +13,13 @@ import { ad as AndroidUtils, layout } from "tns-core-modules/utils/utils";
 import lazy from "tns-core-modules/utils/lazy";
 import { firestore, User } from "./firebase";
 
-declare const android, com, org: any;
+declare const android, com: any;
 
 class DocumentSnapshot extends DocumentSnapshotBase {
   android: com.google.firebase.firestore.DocumentSnapshot;
 
   constructor(public snapshot: com.google.firebase.firestore.DocumentSnapshot) {
-    super(snapshot ? snapshot.getId() : null, snapshot.exists(), firebase.toJsObject(snapshot.getData()));
+    super(snapshot ? snapshot.getId() : null, snapshot.exists(), firebase.toJsObject(snapshot.getData()), convertDocRef(snapshot.getReference()));
     this.android = snapshot;
   }
 }
@@ -125,7 +124,7 @@ firebase.toHashMap = obj => {
           } else if (fieldValue.type === "ARRAY_REMOVE") {
             node.put(property, com.google.firebase.firestore.FieldValue.arrayRemove(fieldValue.value));
           } else {
-            console.log("You found a bug! Please report an issue at https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues, mention fieldValue.type = '" + fieldValue.type + "'. Thanks!")
+            console.log("You found a bug! Please report an issue at https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues, mention fieldValue.type = '" + fieldValue.type + "'. Thanks!");
           }
         } else if (obj[property] instanceof Date) {
           node.put(property, new java.util.Date(obj[property].getTime()));
@@ -279,7 +278,7 @@ firebase.init = arg => {
       arg = arg || {};
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
+        appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
       ).setAnalyticsCollectionEnabled(arg.analyticsCollectionEnabled !== false);
 
       if (typeof (com.google.firebase.database) !== "undefined" && typeof (com.google.firebase.database.ServerValue) !== "undefined") {
@@ -302,9 +301,9 @@ firebase.init = arg => {
         if (!arg.persist) {
           try {
             com.google.firebase.firestore.FirebaseFirestore.getInstance().setFirestoreSettings(
-                new com.google.firebase.firestore.FirebaseFirestoreSettings.Builder()
-                    .setPersistenceEnabled(false)
-                    .build());
+              new com.google.firebase.firestore.FirebaseFirestoreSettings.Builder()
+                .setPersistenceEnabled(false)
+                .build());
           } catch (ignore) {
           }
         }
@@ -537,8 +536,8 @@ firebase.getRemoteConfig = arg => {
 
       // Enable developer mode to allow for frequent refreshes of the cache
       const remoteConfigSettings = new com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder()
-          .setDeveloperModeEnabled(arg.developerMode || false)
-          .build();
+        .setDeveloperModeEnabled(arg.developerMode || false)
+        .build();
       firebaseRemoteConfig.setConfigSettings(remoteConfigSettings);
 
       const defaults = firebase.getRemoteConfigDefaults(arg.properties);
@@ -587,8 +586,8 @@ firebase.getRemoteConfig = arg => {
       const expirationDuration = arg.cacheExpirationSeconds || 43200;
 
       firebaseRemoteConfig.fetch(expirationDuration)
-          .addOnSuccessListener(onSuccessListener)
-          .addOnFailureListener(onFailureListener);
+        .addOnSuccessListener(onSuccessListener)
+        .addOnFailureListener(onFailureListener);
     };
 
     try {
@@ -693,8 +692,8 @@ firebase.getAuthToken = arg => {
         });
 
         user.getIdToken(arg.forceRefresh)
-            .addOnSuccessListener(onSuccessListener)
-            .addOnFailureListener(onFailureListener);
+          .addOnSuccessListener(onSuccessListener)
+          .addOnFailureListener(onFailureListener);
 
       } else {
         reject("Log in first");
@@ -712,7 +711,7 @@ function toLoginResult(user, additionalUserInfo?): User {
   }
 
   if (additionalUserInfo) {
-    firebase.currentAdditionalUserInfo = additionalUserInfo
+    firebase.currentAdditionalUserInfo = additionalUserInfo;
   }
 
   // for convenience return the result in multiple formats
@@ -823,15 +822,15 @@ firebase.login = arg => {
         }
 
         const actionCodeSettings = com.google.firebase.auth.ActionCodeSettings.newBuilder()
-        // URL you want to redirect back to. The domain must be whitelisted in the Firebase Console.
-            .setUrl(arg.emailLinkOptions.url)
-            .setHandleCodeInApp(true)
-            .setIOSBundleId(arg.emailLinkOptions.iOS ? arg.emailLinkOptions.iOS.bundleId : appModule.android.context.getPackageName())
-            .setAndroidPackageName(
-                arg.emailLinkOptions.android ? arg.emailLinkOptions.android.packageName : appModule.android.context.getPackageName(),
-                arg.emailLinkOptions.android ? arg.emailLinkOptions.android.installApp || false : false,
-                arg.emailLinkOptions.android ? arg.emailLinkOptions.android.minimumVersion || "1" : "1")
-            .build();
+          // URL you want to redirect back to. The domain must be whitelisted in the Firebase Console.
+          .setUrl(arg.emailLinkOptions.url)
+          .setHandleCodeInApp(true)
+          .setIOSBundleId(arg.emailLinkOptions.iOS ? arg.emailLinkOptions.iOS.bundleId : appModule.android.context.getPackageName())
+          .setAndroidPackageName(
+            arg.emailLinkOptions.android ? arg.emailLinkOptions.android.packageName : appModule.android.context.getPackageName(),
+            arg.emailLinkOptions.android ? arg.emailLinkOptions.android.installApp || false : false,
+            arg.emailLinkOptions.android ? arg.emailLinkOptions.android.minimumVersion || "1" : "1")
+          .build();
 
         const onEmailLinkCompleteListener = new com.google.android.gms.tasks.OnCompleteListener({
           onComplete: task => {
@@ -908,11 +907,11 @@ firebase.login = arg => {
         firebase._verifyPhoneNumberInProgress = true;
 
         com.google.firebase.auth.PhoneAuthProvider.getInstance().verifyPhoneNumber(
-            arg.phoneOptions.phoneNumber,
-            60, // timeout (in seconds, because of the next argument)
-            java.util.concurrent.TimeUnit.SECONDS,
-            appModule.android.foregroundActivity,
-            new OnVerificationStateChangedCallbacks());
+          arg.phoneOptions.phoneNumber,
+          60, // timeout (in seconds, because of the next argument)
+          java.util.concurrent.TimeUnit.SECONDS,
+          appModule.android.foregroundActivity,
+          new OnVerificationStateChangedCallbacks());
 
       } else if (arg.type === firebase.LoginType.CUSTOM) {
         if (!arg.customOptions || (!arg.customOptions.token && !arg.customOptions.tokenProviderFn)) {
@@ -924,14 +923,14 @@ firebase.login = arg => {
           firebaseAuth.signInWithCustomToken(arg.customOptions.token).addOnCompleteListener(onCompleteListener);
         } else if (arg.customOptions.tokenProviderFn) {
           arg.customOptions.tokenProviderFn()
-              .then(
-                  token => {
-                    firebaseAuth.signInWithCustomToken(token).addOnCompleteListener(onCompleteListener);
-                  },
-                  error => {
-                    reject(error);
-                  }
-              );
+            .then(
+              token => {
+                firebaseAuth.signInWithCustomToken(token).addOnCompleteListener(onCompleteListener);
+              },
+              error => {
+                reject(error);
+              }
+            );
         }
 
       } else if (arg.type === firebase.LoginType.FACEBOOK) {
@@ -942,30 +941,30 @@ firebase.login = arg => {
 
         const fbLoginManager = com.facebook.login.LoginManager.getInstance();
         fbLoginManager.registerCallback(
-            fbCallbackManager,
-            new com.facebook.FacebookCallback({
-              onSuccess: loginResult => {
-                firebase._facebookAccessToken = loginResult.getAccessToken().getToken();
-                const authCredential = com.google.firebase.auth.FacebookAuthProvider.getCredential(firebase._facebookAccessToken);
+          fbCallbackManager,
+          new com.facebook.FacebookCallback({
+            onSuccess: loginResult => {
+              firebase._facebookAccessToken = loginResult.getAccessToken().getToken();
+              const authCredential = com.google.firebase.auth.FacebookAuthProvider.getCredential(firebase._facebookAccessToken);
 
-                const user = com.google.firebase.auth.FirebaseAuth.getInstance().getCurrentUser();
-                if (user) {
-                  if (firebase._alreadyLinkedToAuthProvider(user, "facebook.com")) {
-                    firebaseAuth.signInWithCredential(authCredential).addOnCompleteListener(onCompleteListener);
-                  } else {
-                    user.linkWithCredential(authCredential).addOnCompleteListener(onCompleteListener);
-                  }
-                } else {
+              const user = com.google.firebase.auth.FirebaseAuth.getInstance().getCurrentUser();
+              if (user) {
+                if (firebase._alreadyLinkedToAuthProvider(user, "facebook.com")) {
                   firebaseAuth.signInWithCredential(authCredential).addOnCompleteListener(onCompleteListener);
+                } else {
+                  user.linkWithCredential(authCredential).addOnCompleteListener(onCompleteListener);
                 }
-              },
-              onCancel: () => {
-                reject("Facebook Login canceled");
-              },
-              onError: ex => {
-                reject("Error while trying to login with Fb " + ex);
+              } else {
+                firebaseAuth.signInWithCredential(authCredential).addOnCompleteListener(onCompleteListener);
               }
-            })
+            },
+            onCancel: () => {
+              reject("Facebook Login canceled");
+            },
+            onError: ex => {
+              reject("Error while trying to login with Fb " + ex);
+            }
+          })
         );
 
         let scope = ["public_profile", "email"];
@@ -988,8 +987,8 @@ firebase.login = arg => {
 
         // Configure Google Sign In
         const googleSignInOptionsBuilder = new com.google.android.gms.auth.api.signin.GoogleSignInOptions.Builder(com.google.android.gms.auth.api.signin.GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(clientId)
-            .requestEmail();
+          .requestIdToken(clientId)
+          .requestEmail();
 
         if (arg.googleOptions && arg.googleOptions.hostedDomain) {
           googleSignInOptionsBuilder.setHostedDomain(arg.googleOptions.hostedDomain);
@@ -1004,9 +1003,9 @@ firebase.login = arg => {
         });
 
         firebase._mGoogleApiClient = new com.google.android.gms.common.api.GoogleApiClient.Builder(com.tns.NativeScriptApplication.getInstance())
-            .addOnConnectionFailedListener(onConnectionFailedListener)
-            .addApi(com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
-            .build();
+          .addOnConnectionFailedListener(onConnectionFailedListener)
+          .addApi(com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
+          .build();
 
         const signInIntent = com.google.android.gms.auth.api.Auth.GoogleSignInApi.getSignInIntent(firebase._mGoogleApiClient);
 
@@ -1455,12 +1454,12 @@ firebase.push = (path, val) => {
       const pushInstance = firebase.instance.child(path).push();
 
       pushInstance.setValue(firebase.toValue(val))
-          .addOnSuccessListener(new com.google.android.gms.tasks.OnSuccessListener({
-            onSuccess: () => resolve({key: pushInstance.getKey()})
-          }))
-          .addOnFailureListener(new com.google.android.gms.tasks.OnFailureListener({
-            onFailure: exception => reject(exception.getMessage())
-          }));
+        .addOnSuccessListener(new com.google.android.gms.tasks.OnSuccessListener({
+          onSuccess: () => resolve({key: pushInstance.getKey()})
+        }))
+        .addOnFailureListener(new com.google.android.gms.tasks.OnFailureListener({
+          onFailure: exception => reject(exception.getMessage())
+        }));
 
     } catch (ex) {
       console.log("Error in firebase.push: " + ex);
@@ -1478,12 +1477,12 @@ firebase.setValue = (path, val) => {
       }
 
       firebase.instance.child(path).setValue(firebase.toValue(val))
-          .addOnSuccessListener(new com.google.android.gms.tasks.OnSuccessListener({
-            onSuccess: () => resolve()
-          }))
-          .addOnFailureListener(new com.google.android.gms.tasks.OnFailureListener({
-            onFailure: exception => reject(exception.getMessage())
-          }));
+        .addOnSuccessListener(new com.google.android.gms.tasks.OnSuccessListener({
+          onSuccess: () => resolve()
+        }))
+        .addOnFailureListener(new com.google.android.gms.tasks.OnFailureListener({
+          onFailure: exception => reject(exception.getMessage())
+        }));
 
     } catch (ex) {
       console.log("Error in firebase.setValue: " + ex);
@@ -1510,16 +1509,16 @@ firebase.update = (path, val) => {
 
       if (typeof val === "object") {
         firebase.instance.child(path).updateChildren(firebase.toHashMap(val))
-            .addOnSuccessListener(onSuccessListener)
-            .addOnFailureListener(onFailureListener);
+          .addOnSuccessListener(onSuccessListener)
+          .addOnFailureListener(onFailureListener);
       } else {
         const lastPartOfPath = path.lastIndexOf("/");
         const pathPrefix = path.substring(0, lastPartOfPath);
         const pathSuffix = path.substring(lastPartOfPath + 1);
         const updateObject = '{"' + pathSuffix + '" : "' + val + '"}';
         firebase.instance.child(pathPrefix).updateChildren(firebase.toHashMap(JSON.parse(updateObject)))
-            .addOnSuccessListener(onSuccessListener)
-            .addOnFailureListener(onFailureListener);
+          .addOnSuccessListener(onSuccessListener)
+          .addOnFailureListener(onFailureListener);
       }
     } catch (ex) {
       console.log("Error in firebase.update: " + ex);
@@ -1653,12 +1652,12 @@ firebase.remove = path => {
       }
 
       firebase.instance.child(path).setValue(null)
-          .addOnSuccessListener(new com.google.android.gms.tasks.OnSuccessListener({
-            onSuccess: () => resolve()
-          }))
-          .addOnFailureListener(new com.google.android.gms.tasks.OnFailureListener({
-            onFailure: exception => reject(exception.getMessage())
-          }));
+        .addOnSuccessListener(new com.google.android.gms.tasks.OnSuccessListener({
+          onSuccess: () => resolve()
+        }))
+        .addOnFailureListener(new com.google.android.gms.tasks.OnFailureListener({
+          onFailure: exception => reject(exception.getMessage())
+        }));
     } catch (ex) {
       console.log("Error in firebase.remove: " + ex);
       reject(ex);
@@ -1776,9 +1775,9 @@ firebase.invites.getInvitation = () => {
       });
 
       firebase._mGoogleInviteApiClient = new com.google.android.gms.common.api.GoogleApiClient.Builder(com.tns.NativeScriptApplication.getInstance())
-          .addOnConnectionFailedListener(onConnectionFailedListener)
-          .addApi(com.google.android.gms.appinvite.AppInvite.API)
-          .build();
+        .addOnConnectionFailedListener(onConnectionFailedListener)
+        .addApi(com.google.android.gms.appinvite.AppInvite.API)
+        .build();
 
       firebase._mGoogleInviteApiClient.connect();
 
@@ -1812,8 +1811,8 @@ firebase.invites.getInvitation = () => {
       });
 
       firebaseDynamicLinks.getDynamicLink(appModule.android.startActivity.getIntent())
-          .addOnSuccessListener(onSuccessListener)
-          .addOnFailureListener(onFailureListener);
+        .addOnSuccessListener(onSuccessListener)
+        .addOnFailureListener(onFailureListener);
 
     } catch (ex) {
       console.log("Error in firebase.getInvitation: " + ex);
@@ -1982,12 +1981,12 @@ firebase.firestore.collection = (collectionPath: string): firestore.CollectionRe
 
 firebase.firestore.onDocumentSnapshot = (docRef: com.google.firebase.firestore.DocumentReference, callback: (doc: DocumentSnapshot) => void): () => void => {
   const listener = docRef.addSnapshotListener(new com.google.firebase.firestore.EventListener({
-        onEvent: ((snapshot: com.google.firebase.firestore.DocumentSnapshot, exception) => {
-          if (exception === null) {
-            callback(new DocumentSnapshot(snapshot));
-          }
-        })
-      })
+    onEvent: ((snapshot: com.google.firebase.firestore.DocumentSnapshot, exception) => {
+      if (exception === null) {
+        callback(new DocumentSnapshot(snapshot));
+      }
+    })
+  })
   );
 
   return () => listener.remove();
@@ -1995,30 +1994,25 @@ firebase.firestore.onDocumentSnapshot = (docRef: com.google.firebase.firestore.D
 
 firebase.firestore.onCollectionSnapshot = (colRef: com.google.firebase.firestore.CollectionReference, callback: (snapshot: QuerySnapshot) => void): () => void => {
   const listener = colRef.addSnapshotListener(new com.google.firebase.firestore.EventListener({
-        onEvent: ((snapshot: com.google.firebase.firestore.QuerySnapshot, exception) => {
-          if (exception !== null) {
-            return;
-          }
+    onEvent: ((snapshot: com.google.firebase.firestore.QuerySnapshot, exception: com.google.firebase.firestore.FirebaseFirestoreException) => {
+      if (exception !== null) {
+        console.error('onCollectionSnapshot error code: ' + exception.getCode());
+        return;
+      }
 
-          const docSnapshots: Array<firestore.DocumentSnapshot> = [];
-          for (let i = 0; i < snapshot.size(); i++) {
-            const documentSnapshot: com.google.firebase.firestore.DocumentSnapshot = snapshot.getDocuments().get(i);
-            docSnapshots.push(new DocumentSnapshot(documentSnapshot));
-          }
-          const snap = new QuerySnapshot();
-          snap.docSnapshots = docSnapshots;
-          callback(snap);
-        })
-      })
+      callback(new QuerySnapshot(snapshot));
+    })
+  })
   );
 
   return () => listener.remove();
 };
 
-firebase.firestore._getDocumentReference = (javaObj, collectionPath, documentPath): firestore.DocumentReference => {
+firebase.firestore._getDocumentReference = (javaObj: JDocumentReference, collectionPath, documentPath): firestore.DocumentReference => {
   return {
     discriminator: "docRef",
     id: javaObj.getId(),
+    path: javaObj.getPath(),
     collection: cp => firebase.firestore.collection(`${collectionPath}/${documentPath}/${cp}`),
     set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, javaObj.getId(), data, options),
     get: () => firebase.firestore.getDocument(collectionPath, javaObj.getId()),
@@ -2046,6 +2040,18 @@ firebase.firestore.doc = (collectionPath: string, documentPath?: string): firest
   }
 };
 
+firebase.firestore.docRef = (documentPath: string): firestore.DocumentReference => {
+  if (typeof (com.google.firebase.firestore) === "undefined") {
+    console.log("Make sure firebase-firestore is in the plugin's include.gradle");
+    return null;
+  }
+
+  const db: com.google.firebase.firestore.FirebaseFirestore = com.google.firebase.firestore.FirebaseFirestore.getInstance();
+  const docRef: JDocumentReference = db.document(documentPath);
+
+  return convertDocRef(docRef);
+};
+
 firebase.firestore.add = (collectionPath: string, document: any): Promise<firestore.DocumentReference> => {
   return new Promise<firestore.DocumentReference>((resolve, reject) => {
     try {
@@ -2062,6 +2068,7 @@ firebase.firestore.add = (collectionPath: string, document: any): Promise<firest
           resolve({
             discriminator: "docRef",
             id: docRef.getId(),
+            path: docRef.getPath(),
             collection: cp => firebase.firestore.collection(cp),
             set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, docRef.getId(), data, options),
             get: () => firebase.firestore.getDocument(collectionPath, docRef.getId()),
@@ -2077,9 +2084,9 @@ firebase.firestore.add = (collectionPath: string, document: any): Promise<firest
       });
 
       db.collection(collectionPath)
-          .add(firebase.toValue(document))
-          .addOnSuccessListener(onSuccessListener)
-          .addOnFailureListener(onFailureListener);
+        .add(firebase.toValue(document))
+        .addOnSuccessListener(onSuccessListener)
+        .addOnFailureListener(onFailureListener);
 
     } catch (ex) {
       console.log("Error in firebase.firestore.add: " + ex);
@@ -2110,14 +2117,14 @@ firebase.firestore.set = (collectionPath: string, documentPath: string, document
       const docRef: com.google.firebase.firestore.DocumentReference = db.collection(collectionPath).document(documentPath);
       if (options && options.merge) {
         docRef
-            .set(firebase.toValue(document), com.google.firebase.firestore.SetOptions.merge())
-            .addOnSuccessListener(onSuccessListener)
-            .addOnFailureListener(onFailureListener);
+          .set(firebase.toValue(document), com.google.firebase.firestore.SetOptions.merge())
+          .addOnSuccessListener(onSuccessListener)
+          .addOnFailureListener(onFailureListener);
       } else {
         docRef
-            .set(firebase.toValue(document))
-            .addOnSuccessListener(onSuccessListener)
-            .addOnFailureListener(onFailureListener);
+          .set(firebase.toValue(document))
+          .addOnSuccessListener(onSuccessListener)
+          .addOnFailureListener(onFailureListener);
       }
 
     } catch (ex) {
@@ -2148,9 +2155,9 @@ firebase.firestore.update = (collectionPath: string, documentPath: string, docum
 
       const docRef: com.google.firebase.firestore.DocumentReference = db.collection(collectionPath).document(documentPath);
       docRef
-          .update(firebase.toValue(document))
-          .addOnSuccessListener(onSuccessListener)
-          .addOnFailureListener(onFailureListener);
+        .update(firebase.toValue(document))
+        .addOnSuccessListener(onSuccessListener)
+        .addOnFailureListener(onFailureListener);
 
     } catch (ex) {
       console.log("Error in firebase.firestore.update: " + ex);
@@ -2180,9 +2187,9 @@ firebase.firestore.delete = (collectionPath: string, documentPath: string): Prom
 
       const docRef: com.google.firebase.firestore.DocumentReference = db.collection(collectionPath).document(documentPath);
       docRef
-          .delete()
-          .addOnSuccessListener(onSuccessListener)
-          .addOnFailureListener(onFailureListener);
+        .delete()
+        .addOnSuccessListener(onSuccessListener)
+        .addOnFailureListener(onFailureListener);
 
     } catch (ex) {
       console.log("Error in firebase.firestore.delete: " + ex);
@@ -2209,14 +2216,8 @@ firebase.firestore.getCollection = (collectionPath: string): Promise<firestore.Q
             reject(ex && ex.getReason ? ex.getReason() : ex);
           } else {
             const result: com.google.firebase.firestore.QuerySnapshot = task.getResult();
-            const docSnapshots: Array<firestore.DocumentSnapshot> = [];
-            for (let i = 0; i < result.size(); i++) {
-              const documentSnapshot: com.google.firebase.firestore.DocumentSnapshot = result.getDocuments().get(i);
-              docSnapshots.push(new DocumentSnapshot(documentSnapshot));
-            }
-            const snap = new QuerySnapshot();
-            snap.docSnapshots = docSnapshots;
-            resolve(snap);
+
+            resolve(new QuerySnapshot(result));
           }
         }
       });
@@ -2228,9 +2229,9 @@ firebase.firestore.getCollection = (collectionPath: string): Promise<firestore.Q
       });
 
       db.collection(collectionPath)
-          .get()
-          .addOnCompleteListener(onCompleteListener)
-          .addOnFailureListener(onFailureListener);
+        .get()
+        .addOnCompleteListener(onCompleteListener)
+        .addOnFailureListener(onFailureListener);
 
     } catch (ex) {
       console.log("Error in firebase.firestore.getCollection: " + ex);
@@ -2273,10 +2274,10 @@ firebase.firestore.getDocument = (collectionPath: string, documentPath: string):
       });
 
       db.collection(collectionPath)
-          .document(documentPath)
-          .get()
-          .addOnCompleteListener(onCompleteListener)
-          .addOnFailureListener(onFailureListener);
+        .document(documentPath)
+        .get()
+        .addOnCompleteListener(onCompleteListener)
+        .addOnFailureListener(onFailureListener);
 
     } catch (ex) {
       console.log("Error in firebase.firestore.getDocument: " + ex);
@@ -2295,14 +2296,8 @@ firebase.firestore._getQuery = (collectionPath: string, query: com.google.fireba
             reject(ex && ex.getReason ? ex.getReason() : ex);
           } else {
             const result: com.google.firebase.firestore.QuerySnapshot = task.getResult();
-            const docSnapshots: Array<firestore.DocumentSnapshot> = [];
-            for (let i = 0; i < result.size(); i++) {
-              const documentSnapshot: com.google.firebase.firestore.DocumentSnapshot = result.getDocuments().get(i);
-              docSnapshots.push(new DocumentSnapshot(documentSnapshot));
-            }
-            const snap = new QuerySnapshot();
-            snap.docSnapshots = docSnapshots;
-            resolve(snap);
+
+            resolve(new QuerySnapshot(result));
           }
         }
       });
@@ -2381,5 +2376,87 @@ firebase.firestore.endBefore = (collectionPath: string, snapshot: DocumentSnapsh
   return firebase.firestore._getQuery(collectionPath, query.endBefore(snapshot.android));
 };
 
+export type JDocumentReference = com.google.firebase.firestore.DocumentReference;
+
+function convertDocRef(docRef: JDocumentReference): firestore.DocumentReference {
+  const collectionPath = docRef.getParent().getPath();
+
+  return {
+    discriminator: "docRef",
+    id: docRef.getId(),
+    path: docRef.getPath(),
+    collection: cp => firebase.firestore.collection(`${collectionPath}/${docRef.getId()}/${cp}`),
+    set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, docRef.getId(), data, options),
+    get: () => firebase.firestore.getDocument(collectionPath, docRef.getId()),
+    update: (data: any) => firebase.firestore.update(collectionPath, docRef.getId(), data),
+    delete: () => firebase.firestore.delete(collectionPath, docRef.getId()),
+    onSnapshot: (callback: (doc: DocumentSnapshot) => void) => firebase.firestore.onDocumentSnapshot(docRef, callback),
+    android: docRef
+  };
+}
+
+function convertDocChangeType(type: com.google.firebase.firestore.DocumentChange.Type) {
+  switch (type) {
+    case com.google.firebase.firestore.DocumentChange.Type.ADDED: return 'added';
+    case com.google.firebase.firestore.DocumentChange.Type.MODIFIED: return 'modified';
+    case com.google.firebase.firestore.DocumentChange.Type.REMOVED: return 'removed';
+    default: throw new Error('Unknown DocumentChangeType');
+  }
+}
+
+function convertDocument(qDoc: com.google.firebase.firestore.QueryDocumentSnapshot): firestore.QueryDocumentSnapshot {
+  return new DocumentSnapshot(qDoc);
+}
+
+export class QuerySnapshot implements firestore.QuerySnapshot {
+  private _docSnapshots: firestore.QueryDocumentSnapshot[];
+
+  constructor(
+    private snapshot: com.google.firebase.firestore.QuerySnapshot,
+  ) { }
+
+  get docs(): firestore.QueryDocumentSnapshot[] {
+    const getSnapshots = () => {
+      const docSnapshots: firestore.QueryDocumentSnapshot[] = [];
+      for (let i = 0; i < this.snapshot.size(); i++) {
+        const documentSnapshot: com.google.firebase.firestore.DocumentSnapshot = this.snapshot.getDocuments().get(i);
+        docSnapshots.push(new DocumentSnapshot(documentSnapshot));
+      }
+      this._docSnapshots = docSnapshots;
+
+      return docSnapshots;
+    };
+
+    // The operation is lazy loaded
+    return this._docSnapshots || getSnapshots();
+  }
+  /**
+   * @deprecated use the "docs" property instead
+   */
+  docSnapshots = this.docs as firestore.DocumentSnapshot[]; // It's safe to cast, as our document snapshot already has the data() method
+
+  docChanges(options?: firestore.SnapshotListenOptions): firestore.DocumentChange[] {
+    const docChanges: firestore.DocumentChange[] = [];
+    const jChanges: java.util.List<com.google.firebase.firestore.DocumentChange> = this.snapshot.getDocumentChanges();
+    for (let i = 0; i < jChanges.size(); i++) {
+      const chg: com.google.firebase.firestore.DocumentChange = jChanges.get(i);
+      const type = convertDocChangeType(chg.getType());
+      const doc = convertDocument(chg.getDocument());
+
+      docChanges.push({
+        doc,
+        newIndex: chg.getNewIndex(),
+        oldIndex: chg.getOldIndex(),
+        type,
+      });
+    }
+
+    return docChanges;
+  }
+
+  forEach(callback: (result: firestore.DocumentSnapshot) => void, thisArg?: any): void {
+    this.docSnapshots.map(snapshot => callback(snapshot));
+  }
+}
 
 module.exports = firebase;

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -1,7 +1,6 @@
 import {
   firebase,
   DocumentSnapshot as DocumentSnapshotBase,
-  QuerySnapshot,
   GeoPoint,
   isDocumentReference, FieldValue
 } from "./firebase-common";
@@ -23,7 +22,7 @@ class DocumentSnapshot extends DocumentSnapshotBase {
   ios: FIRDocumentSnapshot;
 
   constructor(snapshot: FIRDocumentSnapshot) {
-    super(snapshot.documentID, snapshot.exists, firebaseUtils.toJsObject(snapshot.data()));
+    super(snapshot.documentID, snapshot.exists, firebaseUtils.toJsObject(snapshot.data()), convertDocRef(snapshot.reference));
     this.ios = snapshot;
   }
 }
@@ -113,17 +112,17 @@ firebase.addAppDelegateMethods = appDelegate => {
       let result = false;
       if (typeof (FBSDKApplicationDelegate) !== "undefined") {
         result = FBSDKApplicationDelegate.sharedInstance().applicationOpenURLSourceApplicationAnnotation(
-            application,
-            url,
-            options.valueForKey(UIApplicationOpenURLOptionsSourceApplicationKey),
-            options.valueForKey(UIApplicationOpenURLOptionsAnnotationKey));
+          application,
+          url,
+          options.valueForKey(UIApplicationOpenURLOptionsSourceApplicationKey),
+          options.valueForKey(UIApplicationOpenURLOptionsAnnotationKey));
       }
 
       if (typeof (GIDSignIn) !== "undefined") {
         result = result || GIDSignIn.sharedInstance().handleURLSourceApplicationAnnotation(
-            url,
-            options.valueForKey(UIApplicationOpenURLOptionsSourceApplicationKey),
-            options.valueForKey(UIApplicationOpenURLOptionsAnnotationKey));
+          url,
+          options.valueForKey(UIApplicationOpenURLOptionsSourceApplicationKey),
+          options.valueForKey(UIApplicationOpenURLOptionsAnnotationKey));
       }
 
       if (typeof (FIRDynamicLink) !== "undefined") {
@@ -476,7 +475,7 @@ firebase.getRemoteConfig = arg => {
 
       const onCompletion = (remoteConfigFetchStatus, error) => {
         if (remoteConfigFetchStatus === FIRRemoteConfigFetchStatus.Success ||
-            remoteConfigFetchStatus === FIRRemoteConfigFetchStatus.Throttled) {
+          remoteConfigFetchStatus === FIRRemoteConfigFetchStatus.Throttled) {
 
           const activated = firebaseRemoteConfig.activateFetched();
 
@@ -593,7 +592,7 @@ function toLoginResult(user, additionalUserInfo?: FIRAdditionalUserInfo): User {
   }
 
   if (additionalUserInfo) {
-    firebase.currentAdditionalUserInfo = additionalUserInfo
+    firebase.currentAdditionalUserInfo = additionalUserInfo;
   }
 
   const providers = [];
@@ -743,22 +742,22 @@ firebase.login = arg => {
         firActionCodeSettings.handleCodeInApp = true;
         firActionCodeSettings.setIOSBundleID(arg.emailLinkOptions.iOS ? arg.emailLinkOptions.iOS.bundleId : NSBundle.mainBundle.bundleIdentifier);
         firActionCodeSettings.setAndroidPackageNameInstallIfNotAvailableMinimumVersion(
-            arg.emailLinkOptions.android ? arg.emailLinkOptions.android.packageName : NSBundle.mainBundle.bundleIdentifier,
-            arg.emailLinkOptions.android ? arg.emailLinkOptions.android.installApp || false : false,
-            arg.emailLinkOptions.android ? arg.emailLinkOptions.android.minimumVersion || "1" : "1");
+          arg.emailLinkOptions.android ? arg.emailLinkOptions.android.packageName : NSBundle.mainBundle.bundleIdentifier,
+          arg.emailLinkOptions.android ? arg.emailLinkOptions.android.installApp || false : false,
+          arg.emailLinkOptions.android ? arg.emailLinkOptions.android.minimumVersion || "1" : "1");
         fAuth.sendSignInLinkToEmailActionCodeSettingsCompletion(
-            arg.emailLinkOptions.email,
-            firActionCodeSettings,
-            (error: NSError) => {
-              if (error) {
-                reject(error.localizedDescription);
-                return;
-              }
-              // The link was successfully sent.
-              // Save the email locally so you don't need to ask the user for it again if they open the link on the same device.
-              firebase.rememberEmailForEmailLinkLogin(arg.emailLinkOptions.email);
-              resolve();
+          arg.emailLinkOptions.email,
+          firActionCodeSettings,
+          (error: NSError) => {
+            if (error) {
+              reject(error.localizedDescription);
+              return;
             }
+            // The link was successfully sent.
+            // Save the email locally so you don't need to ask the user for it again if they open the link on the same device.
+            firebase.rememberEmailForEmailLinkLogin(arg.emailLinkOptions.email);
+            resolve();
+          }
         );
 
       } else if (arg.type === firebase.LoginType.PHONE) {
@@ -802,14 +801,14 @@ firebase.login = arg => {
           fAuth.signInAndRetrieveDataWithCustomTokenCompletion(arg.customOptions.token, onCompletionWithAuthResult);
         } else if (arg.customOptions.tokenProviderFn) {
           arg.customOptions.tokenProviderFn()
-              .then(
-                  token => {
-                    fAuth.signInAndRetrieveDataWithCustomTokenCompletion(token, onCompletionWithAuthResult);
-                  },
-                  error => {
-                    reject(error);
-                  }
-              );
+            .then(
+              token => {
+                fAuth.signInAndRetrieveDataWithCustomTokenCompletion(token, onCompletionWithAuthResult);
+              },
+              error => {
+                reject(error);
+              }
+            );
         }
 
       } else if (arg.type === firebase.LoginType.FACEBOOK) {
@@ -857,9 +856,9 @@ firebase.login = arg => {
         }
 
         fbSDKLoginManager.logInWithReadPermissionsFromViewControllerHandler(
-            scope,
-            null, // the viewcontroller param can be null since by default topmost is taken
-            onFacebookCompletion);
+          scope,
+          null, // the viewcontroller param can be null since by default topmost is taken
+          onFacebookCompletion);
 
       } else if (arg.type === firebase.LoginType.GOOGLE) {
         if (typeof (GIDSignIn) === "undefined") {
@@ -1195,15 +1194,15 @@ firebase.addValueEventListener = (updateCallback, path) => {
     try {
       const where = path === undefined ? FIRDatabase.database().reference() : FIRDatabase.database().reference().childByAppendingPath(path);
       const listener = where.observeEventTypeWithBlockWithCancelBlock(
-          FIRDataEventType.Value,
-          snapshot => {
-            updateCallback(firebase.getCallbackData('ValueChanged', snapshot));
-          },
-          firebaseError => {
-            updateCallback({
-              error: firebaseError.localizedDescription
-            });
+        FIRDataEventType.Value,
+        snapshot => {
+          updateCallback(firebase.getCallbackData('ValueChanged', snapshot));
+        },
+        firebaseError => {
+          updateCallback({
+            error: firebaseError.localizedDescription
           });
+        });
       resolve({
         path: path,
         listeners: [listener]
@@ -1220,13 +1219,13 @@ firebase.getValue = path => {
     try {
       const where = path === undefined ? FIRDatabase.database().reference() : FIRDatabase.database().reference().childByAppendingPath(path);
       const listener = where.observeSingleEventOfTypeWithBlockWithCancelBlock(
-          FIRDataEventType.Value,
-          snapshot => {
-            resolve(firebase.getCallbackData('ValueChanged', snapshot));
-          },
-          firebaseError => {
-            reject(firebaseError.localizedDescription);
-          });
+        FIRDataEventType.Value,
+        snapshot => {
+          resolve(firebase.getCallbackData('ValueChanged', snapshot));
+        },
+        firebaseError => {
+          reject(firebaseError.localizedDescription);
+        });
     } catch (ex) {
       console.log("Error in firebase.getValue: " + ex);
       reject(ex);
@@ -1613,11 +1612,11 @@ firebase.firestore.Transaction = (nativeTransaction: FIRTransaction): firestore.
 firebase.firestore.runTransaction = (updateFunction: (transaction: firestore.Transaction) => Promise<any>): Promise<void> => {
   return new Promise<void>((resolve, reject) => {
     FIRFirestore.firestore().runTransactionWithBlockCompletion(
-        (nativeTransaction: FIRTransaction, err: any) => {
-          const tx = new firebase.firestore.Transaction(nativeTransaction);
-          return updateFunction(tx);
-        },
-        (result, error: NSError) => error ? reject(error.localizedDescription) : resolve());
+      (nativeTransaction: FIRTransaction, err: any) => {
+        const tx = new firebase.firestore.Transaction(nativeTransaction);
+        return updateFunction(tx);
+      },
+      (result, error: NSError) => error ? reject(error.localizedDescription) : resolve());
   });
 };
 
@@ -1676,15 +1675,7 @@ firebase.firestore.onCollectionSnapshot = (colRef: FIRCollectionReference, callb
       return;
     }
 
-    const docSnapshots: Array<firestore.DocumentSnapshot> = [];
-    for (let i = 0, l = snapshot.documents.count; i < l; i++) {
-      const document: FIRQueryDocumentSnapshot = snapshot.documents.objectAtIndex(i);
-      docSnapshots.push(new DocumentSnapshot(document));
-    }
-
-    const snap = new QuerySnapshot();
-    snap.docSnapshots = docSnapshots;
-    callback(snap);
+    callback(new QuerySnapshot(snapshot));
   });
 
   // There's a bug resulting in this function to be undefined..
@@ -1699,10 +1690,11 @@ firebase.firestore.onCollectionSnapshot = (colRef: FIRCollectionReference, callb
   }
 };
 
-firebase.firestore._getDocumentReference = (fIRDocumentReference, collectionPath: string, documentPath: string): firestore.DocumentReference => {
+firebase.firestore._getDocumentReference = (fIRDocumentReference: FIRDocumentReference, collectionPath: string, documentPath: string): firestore.DocumentReference => {
   return {
     discriminator: "docRef",
     id: fIRDocumentReference.documentID,
+    path: fIRDocumentReference.path,
     collection: cp => firebase.firestore.collection(`${collectionPath}/${documentPath}/${cp}`),
     set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, fIRDocumentReference.documentID, data, options),
     get: () => firebase.firestore.getDocument(collectionPath, fIRDocumentReference.documentID),
@@ -1729,6 +1721,15 @@ firebase.firestore.doc = (collectionPath: string, documentPath?: string): firest
   }
 };
 
+firebase.firestore.docRef = (documentPath: string): firestore.DocumentReference => {
+  if (typeof (FIRFirestore) === "undefined") {
+    console.log("Make sure 'Firebase/Firestore' is in the plugin's Podfile");
+    return null;
+  }
+
+  return convertDocRef(FIRFirestore.firestore().documentWithPath(documentPath));
+};
+
 firebase.firestore.add = (collectionPath: string, document: any): Promise<firestore.DocumentReference> => {
   return new Promise((resolve, reject) => {
     try {
@@ -1739,23 +1740,24 @@ firebase.firestore.add = (collectionPath: string, document: any): Promise<firest
       fixSpecialFields(document);
       const defaultFirestore = FIRFirestore.firestore();
       const fIRDocumentReference = defaultFirestore
-          .collectionWithPath(collectionPath)
-          .addDocumentWithDataCompletion(document, (error: NSError) => {
-            if (error) {
-              reject(error.localizedDescription);
-            } else {
-              resolve({
-                discriminator: "docRef",
-                id: fIRDocumentReference.documentID,
-                collection: cp => firebase.firestore.collection(cp),
-                set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, fIRDocumentReference.documentID, data, options),
-                get: () => firebase.firestore.getDocument(collectionPath, fIRDocumentReference.documentID),
-                update: (data: any) => firebase.firestore.update(collectionPath, fIRDocumentReference.documentID, data),
-                delete: () => firebase.firestore.delete(collectionPath, fIRDocumentReference.documentID),
-                onSnapshot: (callback: (doc: DocumentSnapshot) => void) => firebase.firestore.onDocumentSnapshot(fIRDocumentReference, callback)
-              });
-            }
-          });
+        .collectionWithPath(collectionPath)
+        .addDocumentWithDataCompletion(document, (error: NSError) => {
+          if (error) {
+            reject(error.localizedDescription);
+          } else {
+            resolve({
+              discriminator: "docRef",
+              id: fIRDocumentReference.documentID,
+              path: fIRDocumentReference.path,
+              collection: cp => firebase.firestore.collection(cp),
+              set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, fIRDocumentReference.documentID, data, options),
+              get: () => firebase.firestore.getDocument(collectionPath, fIRDocumentReference.documentID),
+              update: (data: any) => firebase.firestore.update(collectionPath, fIRDocumentReference.documentID, data),
+              delete: () => firebase.firestore.delete(collectionPath, fIRDocumentReference.documentID),
+              onSnapshot: (callback: (doc: DocumentSnapshot) => void) => firebase.firestore.onDocumentSnapshot(fIRDocumentReference, callback)
+            });
+          }
+        });
 
     } catch (ex) {
       console.log("Error in firebase.firestore.add: " + ex);
@@ -1775,8 +1777,8 @@ firebase.firestore.set = (collectionPath: string, documentPath: string, document
       fixSpecialFields(document);
 
       const docRef: FIRDocumentReference = FIRFirestore.firestore()
-          .collectionWithPath(collectionPath)
-          .documentWithPath(documentPath);
+        .collectionWithPath(collectionPath)
+        .documentWithPath(documentPath);
 
       if (options && options.merge) {
         docRef.setDataMergeCompletion(document, true, (error: NSError) => {
@@ -1824,7 +1826,7 @@ function fixSpecialField(item): any {
     } else if (fieldValue.type === "ARRAY_REMOVE") {
       return FIRFieldValue.fieldValueForArrayRemove(fieldValue.value);
     } else {
-      console.log("You found a bug! Please report an issue at https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues, mention fieldValue.type = '" + fieldValue.type + "'. Thanks!")
+      console.log("You found a bug! Please report an issue at https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues, mention fieldValue.type = '" + fieldValue.type + "'. Thanks!");
     }
   } else if (item instanceof GeoPoint) {
     const geo = <GeoPoint>item;
@@ -1850,8 +1852,8 @@ firebase.firestore.update = (collectionPath: string, documentPath: string, docum
       fixSpecialFields(document);
 
       const docRef: FIRDocumentReference = FIRFirestore.firestore()
-          .collectionWithPath(collectionPath)
-          .documentWithPath(documentPath);
+        .collectionWithPath(collectionPath)
+        .documentWithPath(documentPath);
 
       docRef.updateDataCompletion(document, (error: NSError) => {
         if (error) {
@@ -1876,8 +1878,8 @@ firebase.firestore.delete = (collectionPath: string, documentPath: string): Prom
       }
 
       const docRef: FIRDocumentReference = FIRFirestore.firestore()
-          .collectionWithPath(collectionPath)
-          .documentWithPath(documentPath);
+        .collectionWithPath(collectionPath)
+        .documentWithPath(documentPath);
 
       docRef.deleteDocumentWithCompletion((error: NSError) => {
         if (error) {
@@ -1903,22 +1905,15 @@ firebase.firestore.getCollection = (collectionPath: string): Promise<firestore.Q
       }
 
       const defaultFirestore = FIRFirestore.firestore();
-      const fIRDocumentReference = defaultFirestore
-          .collectionWithPath(collectionPath)
-          .getDocumentsWithCompletion((snapshot: FIRQuerySnapshot, error: NSError) => {
-            if (error) {
-              reject(error.localizedDescription);
-            } else {
-              const docSnapshots: Array<firestore.DocumentSnapshot> = [];
-              for (let i = 0, l = snapshot.documents.count; i < l; i++) {
-                const document: FIRQueryDocumentSnapshot = snapshot.documents.objectAtIndex(i);
-                docSnapshots.push(new DocumentSnapshot(document));
-              }
-              const snap = new QuerySnapshot();
-              snap.docSnapshots = docSnapshots;
-              resolve(snap);
-            }
-          });
+      defaultFirestore
+        .collectionWithPath(collectionPath)
+        .getDocumentsWithCompletion((snapshot: FIRQuerySnapshot, error: NSError) => {
+          if (error) {
+            reject(error.localizedDescription);
+          } else {
+            resolve(new QuerySnapshot(snapshot));
+          }
+        });
 
     } catch (ex) {
       console.log("Error in firebase.firestore.getCollection: " + ex);
@@ -1940,16 +1935,15 @@ firebase.firestore.getDocument = (collectionPath: string, documentPath: string):
       }
 
       FIRFirestore.firestore()
-          .collectionWithPath(collectionPath)
-          .documentWithPath(documentPath)
-          .getDocumentWithCompletion((snapshot: FIRDocumentSnapshot, error: NSError) => {
-            if (error) {
-              reject(error.localizedDescription);
-            } else {
-              const exists = snapshot.exists;
-              resolve(new DocumentSnapshot(snapshot));
-            }
-          });
+        .collectionWithPath(collectionPath)
+        .documentWithPath(documentPath)
+        .getDocumentWithCompletion((snapshot: FIRDocumentSnapshot, error: NSError) => {
+          if (error) {
+            reject(error.localizedDescription);
+          } else {
+            resolve(new DocumentSnapshot(snapshot));
+          }
+        });
 
     } catch (ex) {
       console.log("Error in firebase.firestore.getDocument: " + ex);
@@ -1965,14 +1959,7 @@ firebase.firestore._getQuery = (collectionPath: string, query: FIRQuery): firest
         if (error) {
           reject(error.localizedDescription);
         } else {
-          const docSnapshots: Array<firestore.DocumentSnapshot> = [];
-          for (let i = 0, l = snapshot.documents.count; i < l; i++) {
-            const document: FIRQueryDocumentSnapshot = snapshot.documents.objectAtIndex(i);
-            docSnapshots.push(new DocumentSnapshot(document));
-          }
-          const snap = new QuerySnapshot();
-          snap.docSnapshots = docSnapshots;
-          resolve(snap);
+          resolve(new QuerySnapshot(snapshot));
         }
       });
     }),
@@ -2089,6 +2076,89 @@ class GIDSignInDelegateImpl extends NSObject implements GIDSignInDelegate {
 
   public signInDidSignInForUserWithError(signIn: GIDSignIn, user: GIDGoogleUser, error: NSError): void {
     this.callback(user, error);
+  }
+}
+
+function convertDocRef(docRef: FIRDocumentReference): firestore.DocumentReference {
+  const collectionPath = docRef.parent.path;
+
+  return {
+    discriminator: "docRef",
+    id: docRef.documentID,
+    path: docRef.path,
+    collection: cp => firebase.firestore.collection(`${collectionPath}/${docRef.documentID}/${cp}`),
+    set: (data: any, options?: firestore.SetOptions) => firebase.firestore.set(collectionPath, docRef.documentID, data, options),
+    get: () => firebase.firestore.getDocument(collectionPath, docRef.documentID),
+    update: (data: any) => firebase.firestore.update(collectionPath, docRef.documentID, data),
+    delete: () => firebase.firestore.delete(collectionPath, docRef.documentID),
+    onSnapshot: (callback: (doc: DocumentSnapshot) => void) => firebase.firestore.onDocumentSnapshot(docRef, callback),
+    ios: docRef
+  };
+}
+
+function convertDocChangeType(type: FIRDocumentChangeType) {
+  switch (type) {
+    case FIRDocumentChangeType.Added: return 'added';
+    case FIRDocumentChangeType.Modified: return 'modified';
+    case FIRDocumentChangeType.Removed: return 'removed';
+    default: throw new Error('Unknown DocumentChangeType');
+  }
+}
+
+function convertDocument(qDoc: FIRQueryDocumentSnapshot): firestore.QueryDocumentSnapshot {
+  return new DocumentSnapshot(qDoc);
+}
+
+export class QuerySnapshot implements firestore.QuerySnapshot {
+  private _docSnapshots: firestore.QueryDocumentSnapshot[];
+
+  constructor(
+    private snapshot: FIRQuerySnapshot,
+  ) { }
+
+  get docs(): firestore.QueryDocumentSnapshot[] {
+    const getSnapshots = () => {
+      const docSnapshots: firestore.QueryDocumentSnapshot[] = [];
+      for (let i = 0, l = this.snapshot.documents.count; i < l; i++) {
+        const document = this.snapshot.documents.objectAtIndex(i);
+        docSnapshots.push(new DocumentSnapshot(document));
+      }
+      this._docSnapshots = docSnapshots;
+
+      return docSnapshots;
+    };
+
+    // The operation is lazy loaded
+    return this._docSnapshots || getSnapshots();
+  }
+
+  /**
+   * @deprecated use the "docs" property instead
+   */
+  docSnapshots = this.docs as firestore.DocumentSnapshot[]; // It's safe to cast, as our document snapshot already has the data() method
+
+  docChanges(options?: firestore.SnapshotListenOptions): firestore.DocumentChange[] {
+    if (options) { console.info('No options support yet, for docChanges()'); }
+    const docChanges: firestore.DocumentChange[] = [];
+    const jChanges: NSArray<FIRDocumentChange> = this.snapshot.documentChanges;
+    for (let i = 0; i < jChanges.count; i++) {
+      const chg = jChanges[i];
+      const type = convertDocChangeType(chg.type);
+      const doc = convertDocument(chg.document);
+
+      docChanges.push({
+        doc,
+        newIndex: chg.newIndex,
+        oldIndex: chg.oldIndex,
+        type,
+      });
+    }
+
+    return docChanges;
+  }
+
+  forEach(callback: (result: firestore.DocumentSnapshot) => void, thisArg?: any): void {
+    this.docSnapshots.map(snapshot => callback(snapshot));
   }
 }
 


### PR DESCRIPTION
Added a few new entities such as `DocumentChange`, `QueryDocumentSnapshot` etc.
`QuerySnapshot` now supports `docChanges()` API.
Added missing `doc()` method for the Web API (Firestore).
Getting `docs()` on a QuerySnapshot is now lazy loaded.
Added missing properties 'path' and 'ref' for DocumentSnapshot and DocumentReference.
Refactored out some redundant code.