### PR TITLE
EmailLinkAuthentication - Don't check action type when resuming app.

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -47,13 +47,10 @@ const dynamicLinksEnabled = lazy(() => typeof (com.google.firebase.dynamiclinks)
       firebaseMessaging.onAppModuleLaunchEvent(args);
     }
 
-    const intent = args.android;
-    const isLaunchIntent = "android.intent.action.VIEW" === intent.getAction();
-
-    if (isLaunchIntent && dynamicLinksEnabled()) {
+    if (dynamicLinksEnabled()) {
       // let's see if this is part of an email-link authentication flow
       const firebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
-      const emailLink = "" + intent.getData();
+      const emailLink = "" + args.android.getData();
       if (firebaseAuth.isSignInWithEmailLink(emailLink)) {
         const rememberedEmail = firebase.getRememberedEmailForEmailLinkLogin();
         if (rememberedEmail !== undefined) {


### PR DESCRIPTION
Hello Eddy,
Email link authentication to me is not working in android.
That's because at startup there is a check on the action type:

        const isLaunchIntent = "android.intent.action.VIEW" === intent.getAction();

That seems to be always false because in reality the type of intent is: _android.intent.action.MAIN_
So, I propose to drop the check on the action type (even in firebase examples they are not checking it) and rather rely on the following check:

          if (firebaseAuth.isSignInWithEmailLink(emailLink)) {

that should prevent us to enter auth code when we should not.

What do you think?

Cheers
