### PR TITLE
Adding authListener to the list of listeners if passed in 'init'

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -312,16 +312,7 @@ firebase.init = arg => {
         const firebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
 
         if (arg.onAuthStateChanged) {
-          firebase.authStateListener = new com.google.firebase.auth.FirebaseAuth.AuthStateListener({
-            onAuthStateChanged: fbAuth => {
-              const user = fbAuth.getCurrentUser();
-              arg.onAuthStateChanged({
-                loggedIn: user !== null,
-                user: toLoginResult(user)
-              });
-            }
-          });
-          firebaseAuth.addAuthStateListener(firebase.authStateListener);
+          firebase.addAuthStateListener(arg.onAuthStateChanged)
         }
 
         // Listen to auth state changes


### PR DESCRIPTION
When the authStateListener is passed through 'init' it's not added to the list of listeners.
This implies that, for example, for an emailLink login, when we have:

    firebase.notifyAuthStateListeners

The state listener is not called.
