### PR TITLE
Fix for when googlePlayServicesVersion is '+'

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -595,7 +595,7 @@ repositories {
 def supportVersion = project.hasProperty("supportVersion") ? project.supportVersion : "26.0.0"
 def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : "16.0.1"
 
-if (VersionNumber.parse(googlePlayServicesVersion) < VersionNumber.parse('15.0.+')) {
+if (googlePlayServicesVersion != '+' && VersionNumber.parse(googlePlayServicesVersion) < VersionNumber.parse('15.0.+')) {
     throw new GradleException(" googlePlayServicesVersion set too low, please update to at least 15.0.0 / 15.0.+ (currently set to $googlePlayServicesVersion)");
 }
 


### PR DESCRIPTION
The app build will fail when using googlePlayServicesVersion, if it's set to '+' despite version being >15.0.0