### PR TITLE
Set 'foreground: false' for iOS Background Notification

### DIFF
--- a/src/messaging/messaging.ios.ts
+++ b/src/messaging/messaging.ios.ts
@@ -427,7 +427,13 @@ function _registerForRemoteNotifications() {
           }
         }
 
-        userInfoJSON.foreground = true;
+        const app = iOSUtils.getter(UIApplication, UIApplication.sharedApplication);
+        if (app.applicationState === UIApplicationState.Active) {
+            userInfoJSON.foreground = true;
+        } else {
+            userInfoJSON.foreground = false;
+        }
+
         _pendingNotifications.push(userInfoJSON);
         if (_receivedNotificationCallback) {
           _processPendingNotifications();


### PR DESCRIPTION
foreground was always true even if the app is opened from a background notification in iOS.