### PR TITLE
onAuthStateChangedListener required for AF2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/platforms/android/include.gradle
 !src/performance/performance.d.ts
 !src/storage/storage.d.ts
 !src/admob/admob.d.ts
+!src/auth/auth.d.ts
 !src/messaging/messaging.d.ts
 !src/mlkit/*/index.d.ts
 !src/mlkit/mlkit-cameraview.d.ts

--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -1,7 +1,7 @@
 import * as firebase from "../../firebase";
 import { FirebaseEmailLinkActionCodeSettings, LoginType, User } from "../../firebase";
 
-export module auth {
+export namespace auth {
   export class Auth {
     private authStateChangedHandler;
     public currentUser: User;
@@ -9,7 +9,22 @@ export module auth {
     public onAuthStateChanged(handler: (user: User) => void): void {
       this.authStateChangedHandler = handler;
       console.log(">> added onAuthStateChanged handler");
-    };
+    }
+
+    public onAuthStateChangedListener(
+      nextOrObserver:
+        | import('firebase').Observer<any>
+        | ((a: import('firebase').User | null) => any),
+      error?: ((a: import('firebase').auth.Error) => any),
+      completed?: import('firebase').Unsubscribe,
+    ): import('firebase').Unsubscribe {
+      const listener = (<any>firebase).auth.addAuthStateListener(nextOrObserver, error);
+      return () => {
+        if (listener) {
+          (<any>firebase).auth.removeAuthStateListener(listener);
+        }
+      };
+    }
 
     public signOut(): Promise<any> {
       return new Promise((resolve, reject) => {
@@ -113,7 +128,7 @@ export module auth {
           this.currentUser = user;
           resolve(user);
         }).catch(err => reject(err));
-      })
+      });
     }
 
     public signInAnonymously(): Promise<any> {

--- a/src/auth/auth.android.ts
+++ b/src/auth/auth.android.ts
@@ -1,6 +1,7 @@
 type JAuthStateListener = com.google.firebase.auth.FirebaseAuth.AuthStateListener;
 type JFirebaseAuth = com.google.firebase.auth.FirebaseAuth;
 type JUserInfo = com.google.firebase.auth.UserInfo;
+type JFirebaseUser = com.google.firebase.auth.FirebaseUser;
 type JFirebaseAuthInvalidUserException = com.google.firebase.auth.FirebaseAuthInvalidUserException;
 type JFirebaseAuthRecentLoginRequiredException = com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException;
 
@@ -15,40 +16,44 @@ export namespace auth {
       const auth: JFirebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
       const listener = new com.google.firebase.auth.FirebaseAuth.AuthStateListener({
         onAuthStateChanged: fbAuth => {
-          const user = fbAuth.getCurrentUser();
-          const meta = (<any>user).getMetadata(); // FIXME: Missing type
-          // TODO: We probably can't satisfy all of a (Web SDK) user object, so figure out what methods are possible.
-          const fbUser = <import('firebase').User>{
-            displayName: user.getDisplayName(),
-            email: user.getEmail(),
-            emailVerified: user.isEmailVerified(),
-            isAnonymous: user.isAnonymous(),
-            phoneNumber: user.getPhoneNumber(),
-            photoURL: user.getPhotoUrl().toString(),
-            providerId: user.getProviderId(),
-            refreshToken: '',
-            uid: user.getUid(),
-            metadata: {
-              creationTime: (new Date(meta.getCreationTimestamp())).toUTCString(),
-              lastSignInTime: (new Date(meta.getLastSignInTimestamp())).toUTCString(),
-            },
-            providerData: convertUserInfo(user.getProviderData()),
-            delete: () => {
-              return new Promise((resolve, reject) => {
-                try {
-                  user.delete();
-                  resolve();
-                } catch (e) {
-                  reject(e); // TODO: What type of error should this be to satisfy the Web SDK?
-                }
-              });
-            }
-          };
+          const user: JFirebaseUser | null = fbAuth.getCurrentUser();
+          let fbUser: import('firebase').User | undefined;
+
+          if (user) {
+            const meta = (<any>user).getMetadata(); // FIXME: Missing type
+            // TODO: We probably can't satisfy all of a (Web SDK) user object, so figure out what methods are possible.
+            fbUser = <import('firebase').User>{
+              displayName: user.getDisplayName(),
+              email: user.getEmail(),
+              emailVerified: user.isEmailVerified(),
+              isAnonymous: user.isAnonymous(),
+              phoneNumber: user.getPhoneNumber(),
+              photoURL: user.getPhotoUrl().toString(),
+              providerId: user.getProviderId(),
+              refreshToken: '',
+              uid: user.getUid(),
+              metadata: {
+                creationTime: (new Date(meta.getCreationTimestamp())).toUTCString(),
+                lastSignInTime: (new Date(meta.getLastSignInTimestamp())).toUTCString(),
+              },
+              providerData: convertUserInfo(user.getProviderData()),
+              delete: () => {
+                return new Promise((resolve, reject) => {
+                  try {
+                    user.delete();
+                    resolve();
+                  } catch (e) {
+                    reject(e); // TODO: What type of error should this be to satisfy the Web SDK?
+                  }
+                });
+              }
+            };
+          }
 
           if (typeof (nextOrObserver) === 'function') {
-            nextOrObserver(fbUser);
+            nextOrObserver(fbUser || null);
           } else {
-            nextOrObserver.next(fbUser);
+            nextOrObserver.next(fbUser || null);
           }
         }
       });

--- a/src/auth/auth.android.ts
+++ b/src/auth/auth.android.ts
@@ -1,0 +1,88 @@
+type JAuthStateListener = com.google.firebase.auth.FirebaseAuth.AuthStateListener;
+type JFirebaseAuth = com.google.firebase.auth.FirebaseAuth;
+type JUserInfo = com.google.firebase.auth.UserInfo;
+type JFirebaseAuthInvalidUserException = com.google.firebase.auth.FirebaseAuthInvalidUserException;
+type JFirebaseAuthRecentLoginRequiredException = com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException;
+
+export namespace auth {
+  export function addAuthStateListener(
+    nextOrObserver:
+      | import('firebase').Observer<any>
+      | ((a: import('firebase').User | null) => any),
+    error?: ((a: import('firebase').auth.Error) => any),
+  ) {
+    try {
+      const auth: JFirebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
+      const listener = new com.google.firebase.auth.FirebaseAuth.AuthStateListener({
+        onAuthStateChanged: fbAuth => {
+          const user = fbAuth.getCurrentUser();
+          const meta = (<any>user).getMetadata(); // FIXME: Missing type
+          // TODO: We probably can't satisfy all of a (Web SDK) user object, so figure out what methods are possible.
+          const fbUser = <import('firebase').User>{
+            displayName: user.getDisplayName(),
+            email: user.getEmail(),
+            emailVerified: user.isEmailVerified(),
+            isAnonymous: user.isAnonymous(),
+            phoneNumber: user.getPhoneNumber(),
+            photoURL: user.getPhotoUrl().toString(),
+            providerId: user.getProviderId(),
+            refreshToken: '',
+            uid: user.getUid(),
+            metadata: {
+              creationTime: (new Date(meta.getCreationTimestamp())).toUTCString(),
+              lastSignInTime: (new Date(meta.getLastSignInTimestamp())).toUTCString(),
+            },
+            providerData: convertUserInfo(user.getProviderData()),
+            delete: () => {
+              return new Promise((resolve, reject) => {
+                try {
+                  user.delete();
+                  resolve();
+                } catch (e) {
+                  reject(e); // TODO: What type of error should this be to satisfy the Web SDK?
+                }
+              });
+            }
+          };
+
+          if (typeof (nextOrObserver) === 'function') {
+            nextOrObserver(fbUser);
+          } else {
+            nextOrObserver.next(fbUser);
+          }
+        }
+      });
+
+      auth.addAuthStateListener(listener);
+
+      return listener;
+    } catch (e) {
+      const err: any = new Error(e.message);
+      err.code = e.code;
+      error(err);
+      return undefined;
+    }
+  }
+
+  export function removeAuthStateListener(listener: JAuthStateListener) {
+    const auth: JFirebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
+    auth.removeAuthStateListener(listener);
+  }
+
+  export function convertUserInfo(data: java.util.List<JUserInfo>): import('firebase').UserInfo[] {
+    const providers: import('firebase').UserInfo[] = [];
+    for (let i = 0; i < data.size(); i++) {
+      const user: JUserInfo = data.get(i);
+      providers.push({
+        displayName: user.getDisplayName(),
+        email: user.getEmail(),
+        phoneNumber: user.getPhoneNumber(),
+        photoURL: user.getPhotoUrl().toString(),
+        providerId: user.getProviderId(),
+        uid: user.getUid(),
+      });
+    }
+
+    return providers;
+  }
+}

--- a/src/auth/auth.d.ts
+++ b/src/auth/auth.d.ts
@@ -1,0 +1,10 @@
+export declare namespace auth {
+  export function addAuthStateListener(
+    nextOrObserver:
+      | import('firebase').Observer<any>
+      | ((a: import('firebase').User | null) => any),
+    error?: ((a: import('firebase').auth.Error) => any),
+  );
+
+  export function removeAuthStateListener(listener: any);
+}

--- a/src/auth/auth.ios.ts
+++ b/src/auth/auth.ios.ts
@@ -8,40 +8,44 @@ export namespace auth {
     try {
       const auth = FIRAuth.auth();
 
-      return auth.addAuthStateDidChangeListener((auth, user) => {
-        // TODO: We probably can't satisfy all of a (Web SDK) user object, so figure out what methods are possible.
-        const fbUser = <import('firebase').User>{
-          displayName: user.displayName,
-          email: user.email,
-          emailVerified: user.emailVerified,
-          isAnonymous: user.anonymous,
-          phoneNumber: user.phoneNumber,
-          photoURL: user.photoURL && user.photoURL.absoluteString,
-          providerId: user.providerID,
-          refreshToken: user.refreshToken,
-          uid: user.uid,
-          metadata: {
-            creationTime: user.metadata.creationDate && user.metadata.creationDate.toUTCString(),
-            lastSignInTime: user.metadata.lastSignInDate && user.metadata.lastSignInDate.toUTCString(),
-          },
-          providerData: convertUserInfo(user.providerData),
-          delete: () => {
-            return new Promise((resolve, reject) => {
-              user.deleteWithCompletion((error?: NSError) => {
-                if (error) {
-                  return reject(error); // TODO: What type of error should this be to satisfy the Web SDK?
-                }
+      return auth.addAuthStateDidChangeListener((auth, user: FIRUser | null) => {
+        let fbUser: import('firebase').User | undefined;
 
-                resolve();
+        if (user) {
+          // TODO: We probably can't satisfy all of a (Web SDK) user object, so figure out what methods are possible.
+          fbUser = <import('firebase').User>{
+            displayName: user.displayName,
+            email: user.email,
+            emailVerified: user.emailVerified,
+            isAnonymous: user.anonymous,
+            phoneNumber: user.phoneNumber,
+            photoURL: user.photoURL && user.photoURL.absoluteString,
+            providerId: user.providerID,
+            refreshToken: user.refreshToken,
+            uid: user.uid,
+            metadata: {
+              creationTime: user.metadata.creationDate && user.metadata.creationDate.toUTCString(),
+              lastSignInTime: user.metadata.lastSignInDate && user.metadata.lastSignInDate.toUTCString(),
+            },
+            providerData: convertUserInfo(user.providerData),
+            delete: () => {
+              return new Promise((resolve, reject) => {
+                user.deleteWithCompletion((error?: NSError) => {
+                  if (error) {
+                    return reject(error); // TODO: What type of error should this be to satisfy the Web SDK?
+                  }
+
+                  resolve();
+                });
               });
-            });
-          }
-        };
+            }
+          };
+        }
 
         if (typeof (nextOrObserver) === 'function') {
-          nextOrObserver(fbUser);
+          nextOrObserver(fbUser || null);
         } else {
-          nextOrObserver.next(fbUser);
+          nextOrObserver.next(fbUser || null);
         }
       });
     } catch (e) {

--- a/src/auth/auth.ios.ts
+++ b/src/auth/auth.ios.ts
@@ -1,0 +1,76 @@
+export namespace auth {
+  export function addAuthStateListener(
+    nextOrObserver:
+      | import('firebase').Observer<any>
+      | ((a: import('firebase').User | null) => any),
+    error?: ((a: import('firebase').auth.Error) => any),
+  ): NSObjectProtocol | undefined {
+    try {
+      const auth = FIRAuth.auth();
+
+      return auth.addAuthStateDidChangeListener((auth, user) => {
+        // TODO: We probably can't satisfy all of a (Web SDK) user object, so figure out what methods are possible.
+        const fbUser = <import('firebase').User>{
+          displayName: user.displayName,
+          email: user.email,
+          emailVerified: user.emailVerified,
+          isAnonymous: user.anonymous,
+          phoneNumber: user.phoneNumber,
+          photoURL: user.photoURL && user.photoURL.absoluteString,
+          providerId: user.providerID,
+          refreshToken: user.refreshToken,
+          uid: user.uid,
+          metadata: {
+            creationTime: user.metadata.creationDate && user.metadata.creationDate.toUTCString(),
+            lastSignInTime: user.metadata.lastSignInDate && user.metadata.lastSignInDate.toUTCString(),
+          },
+          providerData: convertUserInfo(user.providerData),
+          delete: () => {
+            return new Promise((resolve, reject) => {
+              user.deleteWithCompletion((error?: NSError) => {
+                if (error) {
+                  return reject(error); // TODO: What type of error should this be to satisfy the Web SDK?
+                }
+
+                resolve();
+              });
+            });
+          }
+        };
+
+        if (typeof (nextOrObserver) === 'function') {
+          nextOrObserver(fbUser);
+        } else {
+          nextOrObserver.next(fbUser);
+        }
+      });
+    } catch (e) {
+      const err: any = new Error(e.message);
+      err.code = e.code;
+      error(err);
+      return undefined;
+    }
+  }
+
+  export function removeAuthStateListener(listener: NSObjectProtocol) {
+    const auth = FIRAuth.auth();
+    auth.removeAuthStateDidChangeListener(listener);
+  }
+
+  export function convertUserInfo(data: NSArray<FIRUserInfo>): import('firebase').UserInfo[] {
+    const providers: import('firebase').UserInfo[] = [];
+    for (let i = 0, l = data.count; i < l; i++) {
+      const firUserInfo: any = data.objectAtIndex(i); // FIXME: valueForKey not available on type
+      providers.push({
+        displayName: firUserInfo.valueForKey('displayName'),
+        email: firUserInfo.valueForKey('email'),
+        phoneNumber: firUserInfo.valueForKey('phoneNumber'),
+        photoURL: firUserInfo.valueForKey('photoURL') && firUserInfo.valueForKey('photoURL').absoluteString,
+        providerId: firUserInfo.valueForKey('providerID'),
+        uid: firUserInfo.valueForKey('uid'),
+      });
+    }
+
+    return providers;
+  }
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './auth';

--- a/src/firebase-common.ts
+++ b/src/firebase-common.ts
@@ -7,6 +7,7 @@ import * as crashlytics from "./crashlytics/crashlytics";
 import * as performance from "./performance/performance";
 import * as storage from "./storage/storage";
 import * as mlkit from "./mlkit";
+import { auth } from './auth';
 
 // note that this implementation is overridden for iOS
 export class FieldValue {
@@ -34,6 +35,7 @@ export const firebase: any = {
   authStateListeners: [],
   _receivedNotificationCallback: null,
   _dynamicLinkCallback: null,
+  auth,
   admob,
   analytics,
   crashlytics,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ export * from './firebase';
 
 // the modules that have already been extracted from the monolith (which can be imported separately)
 export * from './admob';
+export * from './auth';
 export * from './analytics';
 export * from './crashlytics';
 export * from './performance';

--- a/src/package.json
+++ b/src/package.json
@@ -114,6 +114,7 @@
   "homepage": "https://github.com/eddyverbruggen/nativescript-plugin-firebase",
   "readmeFilename": "README.md",
   "dependencies": {
+    "firebase": "^5.5.9",
     "fs-extra": "~2.1.0",
     "nativescript-hook": "~0.2.4",
     "prompt-lite": "~0.1.0",

--- a/src/platforms/web/typings/firebase-webapi.d.ts
+++ b/src/platforms/web/typings/firebase-webapi.d.ts
@@ -39,54 +39,54 @@ declare namespace firebase {
     delete(): Promise<void>;
     emailVerified: boolean;
     getIdTokenResult(
-        forceRefresh?: boolean
+      forceRefresh?: boolean
     ): Promise<firebase.auth.IdTokenResult>;
     getIdToken(forceRefresh?: boolean): Promise<string>;
     isAnonymous: boolean;
     linkAndRetrieveDataWithCredential(
-        credential: firebase.auth.AuthCredential
+      credential: firebase.auth.AuthCredential
     ): Promise<firebase.auth.UserCredential>;
     linkWithCredential(
-        credential: firebase.auth.AuthCredential
+      credential: firebase.auth.AuthCredential
     ): Promise<firebase.User>;
     linkWithPhoneNumber(
-        phoneNumber: string,
-        applicationVerifier: firebase.auth.ApplicationVerifier
+      phoneNumber: string,
+      applicationVerifier: firebase.auth.ApplicationVerifier
     ): Promise<firebase.auth.ConfirmationResult>;
     linkWithPopup(
-        provider: firebase.auth.AuthProvider
+      provider: firebase.auth.AuthProvider
     ): Promise<firebase.auth.UserCredential>;
     linkWithRedirect(provider: firebase.auth.AuthProvider): Promise<void>;
     metadata: firebase.auth.UserMetadata;
     phoneNumber: string | null;
     providerData: (firebase.UserInfo | null)[];
     reauthenticateAndRetrieveDataWithCredential(
-        credential: firebase.auth.AuthCredential
+      credential: firebase.auth.AuthCredential
     ): Promise<firebase.auth.UserCredential>;
     reauthenticateWithCredential(
-        credential: firebase.auth.AuthCredential
+      credential: firebase.auth.AuthCredential
     ): Promise<void>;
     reauthenticateWithPhoneNumber(
-        phoneNumber: string,
-        applicationVerifier: firebase.auth.ApplicationVerifier
+      phoneNumber: string,
+      applicationVerifier: firebase.auth.ApplicationVerifier
     ): Promise<firebase.auth.ConfirmationResult>;
     reauthenticateWithPopup(
-        provider: firebase.auth.AuthProvider
+      provider: firebase.auth.AuthProvider
     ): Promise<firebase.auth.UserCredential>;
     reauthenticateWithRedirect(
-        provider: firebase.auth.AuthProvider
+      provider: firebase.auth.AuthProvider
     ): Promise<void>;
     refreshToken: string;
     reload(): Promise<void>;
     sendEmailVerification(
-        actionCodeSettings?: firebase.auth.ActionCodeSettings | null
+      actionCodeSettings?: firebase.auth.ActionCodeSettings | null
     ): Promise<void>;
     toJSON(): Object;
     unlink(providerId: string): Promise<firebase.User>;
     updateEmail(newEmail: string): Promise<void>;
     updatePassword(newPassword: string): Promise<void>;
     updatePhoneNumber(
-        phoneCredential: firebase.auth.AuthCredential
+      phoneCredential: firebase.auth.AuthCredential
     ): Promise<void>;
     updateProfile(profile: {
       displayName: string | null;
@@ -145,26 +145,27 @@ declare namespace firebase.functions {
   }
   export class Functions {
     private constructor();
+    useFunctionsEmulator(url: string): void;
     httpsCallable(name: string): HttpsCallable;
   }
   export type ErrorStatus =
-      | 'ok'
-      | 'cancelled'
-      | 'unknown'
-      | 'invalid-argument'
-      | 'deadline-exceeded'
-      | 'not-found'
-      | 'already-exists'
-      | 'permission-denied'
-      | 'resource-exhausted'
-      | 'failed-precondition'
-      | 'aborted'
-      | 'out-of-range'
-      | 'unimplemented'
-      | 'internal'
-      | 'unavailable'
-      | 'data-loss'
-      | 'unauthenticated';
+    | 'ok'
+    | 'cancelled'
+    | 'unknown'
+    | 'invalid-argument'
+    | 'deadline-exceeded'
+    | 'not-found'
+    | 'already-exists'
+    | 'permission-denied'
+    | 'resource-exhausted'
+    | 'failed-precondition'
+    | 'aborted'
+    | 'out-of-range'
+    | 'unimplemented'
+    | 'internal'
+    | 'unavailable'
+    | 'data-loss'
+    | 'unauthenticated';
   export interface HttpsError extends Error {
     readonly code: ErrorStatus;
     readonly details?: any;
@@ -213,12 +214,12 @@ declare namespace firebase.auth {
     checkActionCode(code: string): Promise<firebase.auth.ActionCodeInfo>;
     confirmPasswordReset(code: string, newPassword: string): Promise<void>;
     createUserAndRetrieveDataWithEmailAndPassword(
-        email: string,
-        password: string
+      email: string,
+      password: string
     ): Promise<firebase.auth.UserCredential>;
     createUserWithEmailAndPassword(
-        email: string,
-        password: string
+      email: string,
+      password: string
     ): Promise<firebase.auth.UserCredential>;
     currentUser: firebase.User | null;
     fetchProvidersForEmail(email: string): Promise<Array<string>>;
@@ -228,58 +229,58 @@ declare namespace firebase.auth {
     languageCode: string | null;
     settings: firebase.auth.AuthSettings;
     onAuthStateChanged(
-        nextOrObserver:
-            | firebase.Observer<any>
-            | ((a: firebase.User | null) => any),
-        error?: (a: firebase.auth.Error) => any,
-        completed?: firebase.Unsubscribe
+      nextOrObserver:
+        | firebase.Observer<any>
+        | ((a: firebase.User | null) => any),
+      error?: (a: firebase.auth.Error) => any,
+      completed?: firebase.Unsubscribe
     ): firebase.Unsubscribe;
     onIdTokenChanged(
-        nextOrObserver:
-            | firebase.Observer<any>
-            | ((a: firebase.User | null) => any),
-        error?: (a: firebase.auth.Error) => any,
-        completed?: firebase.Unsubscribe
+      nextOrObserver:
+        | firebase.Observer<any>
+        | ((a: firebase.User | null) => any),
+      error?: (a: firebase.auth.Error) => any,
+      completed?: firebase.Unsubscribe
     ): firebase.Unsubscribe;
     sendSignInLinkToEmail(
-        email: string,
-        actionCodeSettings: firebase.auth.ActionCodeSettings
+      email: string,
+      actionCodeSettings: firebase.auth.ActionCodeSettings
     ): Promise<void>;
     sendPasswordResetEmail(
-        email: string,
-        actionCodeSettings?: firebase.auth.ActionCodeSettings | null
+      email: string,
+      actionCodeSettings?: firebase.auth.ActionCodeSettings | null
     ): Promise<void>;
     setPersistence(persistence: firebase.auth.Auth.Persistence): Promise<void>;
     signInAndRetrieveDataWithCredential(
-        credential: firebase.auth.AuthCredential
+      credential: firebase.auth.AuthCredential
     ): Promise<firebase.auth.UserCredential>;
     signInAnonymously(): Promise<firebase.auth.UserCredential>;
     signInAnonymouslyAndRetrieveData(): Promise<firebase.auth.UserCredential>;
     signInWithCredential(
-        credential: firebase.auth.AuthCredential
+      credential: firebase.auth.AuthCredential
     ): Promise<firebase.User>;
     signInWithCustomToken(token: string): Promise<firebase.auth.UserCredential>;
     signInAndRetrieveDataWithCustomToken(
-        token: string
+      token: string
     ): Promise<firebase.auth.UserCredential>;
     signInWithEmailAndPassword(
-        email: string,
-        password: string
+      email: string,
+      password: string
     ): Promise<firebase.auth.UserCredential>;
     signInAndRetrieveDataWithEmailAndPassword(
-        email: string,
-        password: string
+      email: string,
+      password: string
     ): Promise<firebase.auth.UserCredential>;
     signInWithPhoneNumber(
-        phoneNumber: string,
-        applicationVerifier: firebase.auth.ApplicationVerifier
+      phoneNumber: string,
+      applicationVerifier: firebase.auth.ApplicationVerifier
     ): Promise<firebase.auth.ConfirmationResult>;
     signInWithEmailLink(
-        email: string,
-        emailLink?: string
+      email: string,
+      emailLink?: string
     ): Promise<firebase.auth.UserCredential>;
     signInWithPopup(
-        provider: firebase.auth.AuthProvider
+      provider: firebase.auth.AuthProvider
     ): Promise<firebase.auth.UserCredential>;
     signInWithRedirect(provider: firebase.auth.AuthProvider): Promise<void>;
     signOut(): Promise<void>;
@@ -307,12 +308,12 @@ declare namespace firebase.auth {
     static EMAIL_PASSWORD_SIGN_IN_METHOD: string;
     static EMAIL_LINK_SIGN_IN_METHOD: string;
     static credential(
-        email: string,
-        password: string
+      email: string,
+      password: string
     ): firebase.auth.AuthCredential;
     static credentialWithLink(
-        email: string,
-        emailLink: string
+      email: string,
+      emailLink: string
     ): firebase.auth.AuthCredential;
   }
   class EmailAuthProvider_Instance implements firebase.auth.AuthProvider {
@@ -333,7 +334,7 @@ declare namespace firebase.auth {
     addScope(scope: string): firebase.auth.AuthProvider;
     providerId: string;
     setCustomParameters(
-        customOAuthParameters: Object
+      customOAuthParameters: Object
     ): firebase.auth.AuthProvider;
   }
 
@@ -346,7 +347,7 @@ declare namespace firebase.auth {
     addScope(scope: string): firebase.auth.AuthProvider;
     providerId: string;
     setCustomParameters(
-        customOAuthParameters: Object
+      customOAuthParameters: Object
     ): firebase.auth.AuthProvider;
   }
 
@@ -354,15 +355,15 @@ declare namespace firebase.auth {
     static PROVIDER_ID: string;
     static GOOGLE_SIGN_IN_METHOD: string;
     static credential(
-        idToken?: string | null,
-        accessToken?: string | null
+      idToken?: string | null,
+      accessToken?: string | null
     ): firebase.auth.AuthCredential;
   }
   class GoogleAuthProvider_Instance implements firebase.auth.AuthProvider {
     addScope(scope: string): firebase.auth.AuthProvider;
     providerId: string;
     setCustomParameters(
-        customOAuthParameters: Object
+      customOAuthParameters: Object
     ): firebase.auth.AuthProvider;
   }
 
@@ -381,26 +382,26 @@ declare namespace firebase.auth {
     static PROVIDER_ID: string;
     static PHONE_SIGN_IN_METHOD: string;
     static credential(
-        verificationId: string,
-        verificationCode: string
+      verificationId: string,
+      verificationCode: string
     ): firebase.auth.AuthCredential;
   }
   class PhoneAuthProvider_Instance implements firebase.auth.AuthProvider {
     constructor(auth?: firebase.auth.Auth | null);
     providerId: string;
     verifyPhoneNumber(
-        phoneNumber: string,
-        applicationVerifier: firebase.auth.ApplicationVerifier
+      phoneNumber: string,
+      applicationVerifier: firebase.auth.ApplicationVerifier
     ): Promise<string>;
   }
 
   class RecaptchaVerifier extends RecaptchaVerifier_Instance {}
   class RecaptchaVerifier_Instance
-      implements firebase.auth.ApplicationVerifier {
+    implements firebase.auth.ApplicationVerifier {
     constructor(
-        container: any | string,
-        parameters?: Object | null,
-        app?: firebase.app.App | null
+      container: any | string,
+      parameters?: Object | null,
+      app?: firebase.app.App | null
     );
     clear(): void;
     render(): Promise<number>;
@@ -412,14 +413,14 @@ declare namespace firebase.auth {
     static PROVIDER_ID: string;
     static TWITTER_SIGN_IN_METHOD: string;
     static credential(
-        token: string,
-        secret: string
+      token: string,
+      secret: string
     ): firebase.auth.AuthCredential;
   }
   class TwitterAuthProvider_Instance implements firebase.auth.AuthProvider {
     providerId: string;
     setCustomParameters(
-        customOAuthParameters: Object
+      customOAuthParameters: Object
     ): firebase.auth.AuthProvider;
   }
 
@@ -451,7 +452,7 @@ declare namespace firebase.database {
     exists(): boolean;
     exportVal(): any;
     forEach(
-        action: (a: firebase.database.DataSnapshot) => boolean | void
+      action: (a: firebase.database.DataSnapshot) => boolean | void
     ): boolean;
     getPriority(): string | number | null;
     hasChild(path: string): boolean;
@@ -476,48 +477,48 @@ declare namespace firebase.database {
     remove(onComplete?: (a: Error | null) => any): Promise<any>;
     set(value: any, onComplete?: (a: Error | null) => any): Promise<any>;
     setWithPriority(
-        value: any,
-        priority: number | string | null,
-        onComplete?: (a: Error | null) => any
+      value: any,
+      priority: number | string | null,
+      onComplete?: (a: Error | null) => any
     ): Promise<any>;
     update(values: Object, onComplete?: (a: Error | null) => any): Promise<any>;
   }
 
   type EventType =
-      | 'value'
-      | 'child_added'
-      | 'child_changed'
-      | 'child_moved'
-      | 'child_removed';
+    | 'value'
+    | 'child_added'
+    | 'child_changed'
+    | 'child_moved'
+    | 'child_removed';
 
   interface Query {
     endAt(
-        value: number | string | boolean | null,
-        key?: string
+      value: number | string | boolean | null,
+      key?: string
     ): firebase.database.Query;
     equalTo(
-        value: number | string | boolean | null,
-        key?: string
+      value: number | string | boolean | null,
+      key?: string
     ): firebase.database.Query;
     isEqual(other: firebase.database.Query | null): boolean;
     limitToFirst(limit: number): firebase.database.Query;
     limitToLast(limit: number): firebase.database.Query;
     off(
-        eventType?: EventType,
-        callback?: (a: firebase.database.DataSnapshot, b?: string | null) => any,
-        context?: Object | null
+      eventType?: EventType,
+      callback?: (a: firebase.database.DataSnapshot, b?: string | null) => any,
+      context?: Object | null
     ): any;
     on(
-        eventType: EventType,
-        callback: (a: firebase.database.DataSnapshot | null, b?: string) => any,
-        cancelCallbackOrContext?: Object | null,
-        context?: Object | null
+      eventType: EventType,
+      callback: (a: firebase.database.DataSnapshot | null, b?: string) => any,
+      cancelCallbackOrContext?: Object | null,
+      context?: Object | null
     ): (a: firebase.database.DataSnapshot | null, b?: string) => any;
     once(
-        eventType: EventType,
-        successCallback?: (a: firebase.database.DataSnapshot, b?: string) => any,
-        failureCallbackOrContext?: Object | null,
-        context?: Object | null
+      eventType: EventType,
+      successCallback?: (a: firebase.database.DataSnapshot, b?: string) => any,
+      failureCallbackOrContext?: Object | null,
+      context?: Object | null
     ): Promise<DataSnapshot>;
     orderByChild(path: string): firebase.database.Query;
     orderByKey(): firebase.database.Query;
@@ -525,8 +526,8 @@ declare namespace firebase.database {
     orderByValue(): firebase.database.Query;
     ref: firebase.database.Reference;
     startAt(
-        value: number | string | boolean | null,
-        key?: string
+      value: number | string | boolean | null,
+      key?: string
     ): firebase.database.Query;
     toJSON(): Object;
     toString(): string;
@@ -538,40 +539,40 @@ declare namespace firebase.database {
     onDisconnect(): firebase.database.OnDisconnect;
     parent: firebase.database.Reference | null;
     push(
-        value?: any,
-        onComplete?: (a: Error | null) => any
+      value?: any,
+      onComplete?: (a: Error | null) => any
     ): firebase.database.ThenableReference;
     remove(onComplete?: (a: Error | null) => any): Promise<any>;
     root: firebase.database.Reference;
     set(value: any, onComplete?: (a: Error | null) => any): Promise<any>;
     setPriority(
-        priority: string | number | null,
-        onComplete: (a: Error | null) => any
+      priority: string | number | null,
+      onComplete: (a: Error | null) => any
     ): Promise<any>;
     setWithPriority(
-        newVal: any,
-        newPriority: string | number | null,
-        onComplete?: (a: Error | null) => any
+      newVal: any,
+      newPriority: string | number | null,
+      onComplete?: (a: Error | null) => any
     ): Promise<any>;
     transaction(
-        transactionUpdate: (a: any) => any,
-        onComplete?: (
-            a: Error | null,
-            b: boolean,
-            c: firebase.database.DataSnapshot | null
-        ) => any,
-        applyLocally?: boolean
+      transactionUpdate: (a: any) => any,
+      onComplete?: (
+        a: Error | null,
+        b: boolean,
+        c: firebase.database.DataSnapshot | null
+      ) => any,
+      applyLocally?: boolean
     ): Promise<any>;
     update(values: Object, onComplete?: (a: Error | null) => any): Promise<any>;
   }
 
   interface ThenableReference
-      extends firebase.database.Reference,
-          PromiseLike<any> {}
+    extends firebase.database.Reference,
+      PromiseLike<any> {}
 
   function enableLogging(
-      logger?: boolean | ((a: string) => any),
-      persistent?: boolean
+    logger?: boolean | ((a: string) => any),
+    persistent?: boolean
   ): any;
 }
 
@@ -584,18 +585,18 @@ declare namespace firebase.messaging {
     deleteToken(token: string): Promise<boolean>;
     getToken(): Promise<string | null>;
     onMessage(
-        nextOrObserver: firebase.NextFn<any> | firebase.Observer<any>,
-        error?: firebase.ErrorFn,
-        completed?: firebase.CompleteFn
+      nextOrObserver: firebase.NextFn<any> | firebase.Observer<any>,
+      error?: firebase.ErrorFn,
+      completed?: firebase.CompleteFn
     ): firebase.Unsubscribe;
     onTokenRefresh(
-        nextOrObserver: firebase.NextFn<any> | firebase.Observer<any>,
-        error?: firebase.ErrorFn,
-        completed?: firebase.CompleteFn
+      nextOrObserver: firebase.NextFn<any> | firebase.Observer<any>,
+      error?: firebase.ErrorFn,
+      completed?: firebase.CompleteFn
     ): firebase.Unsubscribe;
     requestPermission(): Promise<void>;
     setBackgroundMessageHandler(
-        callback: (payload: any) => Promise<any> | void
+      callback: (payload: any) => Promise<any> | void
     ): void;
     useServiceWorker(registration: ServiceWorkerRegistration): void;
     usePublicVapidKey(b64PublicKey: string): void;
@@ -632,13 +633,13 @@ declare namespace firebase.storage {
     name: string;
     parent: firebase.storage.Reference | null;
     put(
-        data: any | any | any,
-        metadata?: firebase.storage.UploadMetadata
+      data: any | any | any,
+      metadata?: firebase.storage.UploadMetadata
     ): firebase.storage.UploadTask;
     putString(
-        data: string,
-        format?: firebase.storage.StringFormat,
-        metadata?: firebase.storage.UploadMetadata
+      data: string,
+      format?: firebase.storage.StringFormat,
+      metadata?: firebase.storage.UploadMetadata
     ): firebase.storage.UploadTask;
     root: firebase.storage.Reference;
     storage: firebase.storage.Storage;
@@ -697,17 +698,17 @@ declare namespace firebase.storage {
     cancel(): boolean;
     catch(onRejected: (a: Error) => any): Promise<any>;
     on(
-        event: firebase.storage.TaskEvent,
-        nextOrObserver?: firebase.Observer<any> | null | ((a: Object) => any),
-        error?: ((a: Error) => any) | null,
-        complete?: (firebase.Unsubscribe) | null
+      event: firebase.storage.TaskEvent,
+      nextOrObserver?: firebase.Observer<any> | null | ((a: Object) => any),
+      error?: ((a: Error) => any) | null,
+      complete?: (firebase.Unsubscribe) | null
     ): Function;
     pause(): boolean;
     resume(): boolean;
     snapshot: firebase.storage.UploadTaskSnapshot;
     then(
-        onFulfilled?: ((a: firebase.storage.UploadTaskSnapshot) => any) | null,
-        onRejected?: ((a: Error) => any) | null
+      onFulfilled?: ((a: firebase.storage.UploadTaskSnapshot) => any) | null,
+      onRejected?: ((a: Error) => any) | null
     ): Promise<any>;
   }
 
@@ -862,7 +863,7 @@ declare namespace firebase.firestore {
      * error will be returned.
      */
     runTransaction<T>(
-        updateFunction: (transaction: Transaction) => Promise<T>
+      updateFunction: (transaction: Transaction) => Promise<T>
     ): Promise<T>;
 
     /**
@@ -1069,9 +1070,9 @@ declare namespace firebase.firestore {
      * @return This `Transaction` instance. Used for chaining method calls.
      */
     set(
-        documentRef: DocumentReference,
-        data: DocumentData,
-        options?: SetOptions
+      documentRef: DocumentReference,
+      data: DocumentData,
+      options?: SetOptions
     ): Transaction;
 
     /**
@@ -1103,10 +1104,10 @@ declare namespace firebase.firestore {
      * to the backend (Note that it won't resolve while you're offline).
      */
     update(
-        documentRef: DocumentReference,
-        field: string | FieldPath,
-        value: any,
-        ...moreFieldsAndValues: any[]
+      documentRef: DocumentReference,
+      field: string | FieldPath,
+      value: any,
+      ...moreFieldsAndValues: any[]
     ): Transaction;
 
     /**
@@ -1143,9 +1144,9 @@ declare namespace firebase.firestore {
      * @return This `WriteBatch` instance. Used for chaining method calls.
      */
     set(
-        documentRef: DocumentReference,
-        data: DocumentData,
-        options?: SetOptions
+      documentRef: DocumentReference,
+      data: DocumentData,
+      options?: SetOptions
     ): WriteBatch;
 
     /**
@@ -1176,10 +1177,10 @@ declare namespace firebase.firestore {
      * to the backend (Note that it won't resolve while you're offline).
      */
     update(
-        documentRef: DocumentReference,
-        field: string | FieldPath,
-        value: any,
-        ...moreFieldsAndValues: any[]
+      documentRef: DocumentReference,
+      field: string | FieldPath,
+      value: any,
+      ...moreFieldsAndValues: any[]
     ): WriteBatch;
 
     /**
@@ -1350,9 +1351,9 @@ declare namespace firebase.firestore {
      * to the backend (Note that it won't resolve while you're offline).
      */
     update(
-        field: string | FieldPath,
-        value: any,
-        ...moreFieldsAndValues: any[]
+      field: string | FieldPath,
+      value: any,
+      ...moreFieldsAndValues: any[]
     ): Promise<void>;
 
     /**
@@ -1401,23 +1402,23 @@ declare namespace firebase.firestore {
       complete?: () => void;
     }): () => void;
     onSnapshot(
-        options: SnapshotListenOptions,
-        observer: {
-          next?: (snapshot: DocumentSnapshot) => void;
-          error?: (error: Error) => void;
-          complete?: () => void;
-        }
+      options: SnapshotListenOptions,
+      observer: {
+        next?: (snapshot: DocumentSnapshot) => void;
+        error?: (error: Error) => void;
+        complete?: () => void;
+      }
     ): () => void;
     onSnapshot(
-        onNext: (snapshot: DocumentSnapshot) => void,
-        onError?: (error: Error) => void,
-        onCompletion?: () => void
+      onNext: (snapshot: DocumentSnapshot) => void,
+      onError?: (error: Error) => void,
+      onCompletion?: () => void
     ): () => void;
     onSnapshot(
-        options: SnapshotListenOptions,
-        onNext: (snapshot: DocumentSnapshot) => void,
-        onError?: (error: Error) => void,
-        onCompletion?: () => void
+      options: SnapshotListenOptions,
+      onNext: (snapshot: DocumentSnapshot) => void,
+      onError?: (error: Error) => void,
+      onCompletion?: () => void
     ): () => void;
   }
 
@@ -1608,9 +1609,9 @@ declare namespace firebase.firestore {
      * @return The created Query.
      */
     where(
-        fieldPath: string | FieldPath,
-        opStr: WhereFilterOp,
-        value: any
+      fieldPath: string | FieldPath,
+      opStr: WhereFilterOp,
+      value: any
     ): Query;
 
     /**
@@ -1623,8 +1624,8 @@ declare namespace firebase.firestore {
      * @return The created Query.
      */
     orderBy(
-        fieldPath: string | FieldPath,
-        directionStr?: OrderByDirection
+      fieldPath: string | FieldPath,
+      directionStr?: OrderByDirection
     ): Query;
 
     /**
@@ -1768,23 +1769,23 @@ declare namespace firebase.firestore {
       complete?: () => void;
     }): () => void;
     onSnapshot(
-        options: SnapshotListenOptions,
-        observer: {
-          next?: (snapshot: QuerySnapshot) => void;
-          error?: (error: Error) => void;
-          complete?: () => void;
-        }
+      options: SnapshotListenOptions,
+      observer: {
+        next?: (snapshot: QuerySnapshot) => void;
+        error?: (error: Error) => void;
+        complete?: () => void;
+      }
     ): () => void;
     onSnapshot(
-        onNext: (snapshot: QuerySnapshot) => void,
-        onError?: (error: Error) => void,
-        onCompletion?: () => void
+      onNext: (snapshot: QuerySnapshot) => void,
+      onError?: (error: Error) => void,
+      onCompletion?: () => void
     ): () => void;
     onSnapshot(
-        options: SnapshotListenOptions,
-        onNext: (snapshot: QuerySnapshot) => void,
-        onError?: (error: Error) => void,
-        onCompletion?: () => void
+      options: SnapshotListenOptions,
+      onNext: (snapshot: QuerySnapshot) => void,
+      onError?: (error: Error) => void,
+      onCompletion?: () => void
     ): () => void;
   }
 
@@ -1836,8 +1837,8 @@ declare namespace firebase.firestore {
      * @param thisArg The `this` binding for the callback.
      */
     forEach(
-        callback: (result: QueryDocumentSnapshot) => void,
-        thisArg?: any
+      callback: (result: QueryDocumentSnapshot) => void,
+      thisArg?: any
     ): void;
 
     /**
@@ -2054,25 +2055,25 @@ declare namespace firebase.firestore {
    *   credentials for the operation.
    */
   export type FirestoreErrorCode =
-      | 'cancelled'
-      | 'unknown'
-      | 'invalid-argument'
-      | 'deadline-exceeded'
-      | 'not-found'
-      | 'already-exists'
-      | 'permission-denied'
-      | 'resource-exhausted'
-      | 'failed-precondition'
-      | 'aborted'
-      | 'out-of-range'
-      | 'unimplemented'
-      | 'internal'
-      | 'unavailable'
-      | 'data-loss'
-      | 'unauthenticated';
+    | 'cancelled'
+    | 'unknown'
+    | 'invalid-argument'
+    | 'deadline-exceeded'
+    | 'not-found'
+    | 'already-exists'
+    | 'permission-denied'
+    | 'resource-exhausted'
+    | 'failed-precondition'
+    | 'aborted'
+    | 'out-of-range'
+    | 'unimplemented'
+    | 'internal'
+    | 'unavailable'
+    | 'data-loss'
+    | 'unauthenticated';
 
   /** An error returned by a Firestore operation. */
-    // TODO(b/63008957): FirestoreError should extend firebase.FirebaseError
+  // TODO(b/63008957): FirestoreError should extend firebase.FirebaseError
   export interface FirestoreError {
     code: FirestoreErrorCode;
     message: string;


### PR DESCRIPTION
This PR add native support for `onAuthStateChanged` (named: onAuthStateChangedListener as onAuthStateChanged is in use).

The listener is supposed to emit immediately when registered, as stated here: [Docs](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth.html#addAuthStateListener(com.google.firebase.auth.FirebaseAuth.AuthStateListener)). This makes it behave more like the Web SDK, and is required for my AngularFire2 conversion.

Since this is new code, I’ve also taken steps to move towards the Web SDK user object. It doesn’t return a complete web user object yet (and probably never will); I’ve made a TODO to decide what additional methods are required. I figure this is OK, since its not a publicly supported API yet.

An additional side-effect of the above requirement is importing the typings **ONLY** from the official firebase npm module. To only import the typings I use typescript 2.9’s “import” syntax, which prompted an update of typescript (which I brought up to the latest version). Also updated tns-core-modules and declarations while I was at it.

I haven’t modified any existing code, so backwards compatibility should be fine.