### PR TITLE
Make signInWithEmailAndPassword resolve and reject consistent with web api

### DIFF
--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -20,9 +20,20 @@ export module auth {
               resolve();
             })
             .catch(err => {
+              let code = 'auth/exception';
+              let message = err.toString();
+              if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidCredentialsException')) {
+                code = 'auth/wrong-password';
+              } else if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidUserException')) {
+                code = 'auth/user-not-found';
+              } else if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidUserException')) {
+                code = 'auth/invalid-email'
+              }
+               // Note that auth/user-disabled cannot be identified here because FirebaseAuthInvalidUserException is thrown for both
+               // auth/user-disabled and auth/user-not-found
               reject({
-                // code: "",
-                message: err
+                code: code,
+                message: message,
               });
             });
       });

--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -39,7 +39,12 @@ export module auth {
         }).then((user: User) => {
           this.currentUser = user;
           this.authStateChangedHandler && this.authStateChangedHandler(user);
-          resolve();
+          resolve({
+            additionalUserInfo: user.additionalUserInfo,
+            credential: null,
+            operationType: "SignIn",
+            user: user,
+          });
         }, (err => {
           reject({
             // code: "",

--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -20,21 +20,12 @@ export module auth {
               resolve();
             })
             .catch(err => {
-              let code = 'auth/exception';
-              let message = err.toString();
-              if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidCredentialsException')) {
-                code = 'auth/wrong-password';
-              } else if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidUserException')) {
-                code = 'auth/user-not-found';
-              } else if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidUserException')) {
-                code = 'auth/invalid-email'
-              }
                // Note that auth/user-disabled cannot be identified here because FirebaseAuthInvalidUserException is thrown for both
                // auth/user-disabled and auth/user-not-found
-              reject({
-                code: code,
-                message: message,
-              });
+              reject(
+                // code: "",
+                message: err
+              );
             });
       });
     }
@@ -57,9 +48,23 @@ export module auth {
             user: user,
           });
         }, (err => {
+          {
+            let code = 'auth/exception';
+            let message = err.toString();
+            // Identify code for android. Note that the IOS implementation doesn't return a code.
+            if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidCredentialsException')) {
+              code = 'auth/wrong-password';
+            } else if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidUserException')) {
+              code = 'auth/user-not-found';
+            // Note that Android returns one exception for both user not found and invalid email whereas
+            // the web api returns seperate codes. Therefore the conditional below can never be satisfied
+            // for android.
+            // } else if (message.includes('com.google.firebase.auth.FirebaseAuthInvalidUserException')) {
+            //   code = 'auth/invalid-email'
+          }
           reject({
-            // code: "",
-            message: err
+            code: code,
+            message: message,
           });
         }));
       });

--- a/src/app/auth/index.ts
+++ b/src/app/auth/index.ts
@@ -20,12 +20,10 @@ export module auth {
               resolve();
             })
             .catch(err => {
-               // Note that auth/user-disabled cannot be identified here because FirebaseAuthInvalidUserException is thrown for both
-               // auth/user-disabled and auth/user-not-found
-              reject(
+              reject({
                 // code: "",
                 message: err
-              );
+              });
             });
       });
     }


### PR DESCRIPTION
Passes tests, should be backwards compatible. 

The error message from firebase.login contains additional formatting that isn't consistent with the web api. For example firebase.login formats the error as: 
"Logging in the user failed. com.google.firebase.auth.FirebaseAuthInvalidCredentialsException: The password is invalid or the user does not have a password."
but the web api's error message would just be "The password is invalid or the user does not have a password." Changing the error message could be considered breaking so I didn't make that change.

See https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signInWithEmailAndPassword for web api docs.