### PR TITLE
Dynamic links can be enabled without fauth

### DIFF
--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -159,8 +159,9 @@ firebase.addAppDelegateMethods = appDelegate => {
 
       if (userActivity.webpageURL) {
         // check for an email-link-login flow
-        const fAuth = FIRAuth.auth();
-        if (fAuth.isSignInWithEmailLink(userActivity.webpageURL.absoluteString)) {
+
+        const fAuth = (typeof (FIRAuth) !== "undefined") ? FIRAuth.auth() : undefined;
+        if (fAuth && fAuth.isSignInWithEmailLink(userActivity.webpageURL.absoluteString)) {
           const rememberedEmail = firebase.getRememberedEmailForEmailLinkLogin();
           if (rememberedEmail !== undefined) {
 


### PR DESCRIPTION
IOS: Avoid crashing when dynamic links is enabled without FIRAuth