### PR TITLE
Register FirebasePluginLifecycleCallbacks on app-launch 

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -43,6 +43,9 @@ const dynamicLinksEnabled = lazy(() => typeof (com.google.firebase.dynamiclinks)
 (() => {
   // note that this means we need to 'require()' the plugin before the app is loaded
   appModule.on(appModule.launchEvent, args => {
+    if (messagingEnabled()) {
+      firebaseMessaging.onAppModuleLaunchEvent(args);
+    }
     if (dynamicLinksEnabled()) {
       // let's see if this is part of an email-link authentication flow
       const emailLink = "" + args.android.getData();

--- a/src/messaging/messaging.android.ts
+++ b/src/messaging/messaging.android.ts
@@ -45,9 +45,11 @@ export function initFirebaseMessaging(options?: MessagingOptions) {
   }
 }
 
-export function onAppModuleResumeEvent(args: any) {
+export function onAppModuleLaunchEvent(args: any) {
   org.nativescript.plugins.firebase.FirebasePluginLifecycleCallbacks.registerCallbacks(appModule.android.nativeApp);
+}
 
+export function onAppModuleResumeEvent(args: any) {
   const intent = args.android.getIntent();
   const extras = intent.getExtras();
 

--- a/src/messaging/messaging.d.ts
+++ b/src/messaging/messaging.d.ts
@@ -29,6 +29,7 @@ export declare function areNotificationsEnabled(): boolean;
 export declare const onTokenRefreshNotification: (token: string) => void;
 
 // android. ...
+export declare function onAppModuleLaunchEvent(intent: any): void;
 export declare function onAppModuleResumeEvent(intent: any): void;
 
 export declare class IosInteractivePushSettings {


### PR DESCRIPTION
(Foreground: false) for foreground notifications until app is launched from a background notification and app-resume event was executed without this fix.