### PR TITLE
Corrected misleading documentation.

### DIFF
--- a/docs/ADMOB.md
+++ b/docs/ADMOB.md
@@ -48,7 +48,7 @@ Go [manage your AdMob app](https://apps.admob.com/#account/appmgmt:) and grab th
     size: firebase.admob.AD_SIZE.SMART_BANNER, // see firebase.admob.AD_SIZE for all options
     margins: { // optional nr of device independent pixels from the top or bottom (don't set both)
       bottom: 10,
-      top: 0
+      top: -1
     },
     androidBannerId: "ca-app-pub-9517346003011652/7749101329",
     iosBannerId: "ca-app-pub-9517346003011652/3985369721",


### PR DESCRIPTION
It's true that we shouldn't set both, but it could be understood (ad I did :) ) that leaving one of the two as equal to zero is enough.
This is not true on ios: only one margin should be set OR set both but leave one equal to -1
