### PR TITLE
Document serverTimestamp() Android compatibility

### DIFF
--- a/docs/FIRESTORE.md
+++ b/docs/FIRESTORE.md
@@ -185,6 +185,8 @@ sanFranciscoDocument.update({
 });
 ```
 
+> NB: serverTimestamp() only works in an update on the Android SDK, not add or set.
+
 ### `collection.where()`
 Firestore supports advanced querying with the `where` function. Those `where` clauses can be chained to form logical 'AND' queries:
 


### PR DESCRIPTION
Just adding a note to the firestore docs - I ran into the following error when trying to use serverTimestamp() in .add() on Android:

`Error adding document:  Error: java.lang.RuntimeException: No properties to serialize found on class com.google.firebase.firestore.FieldValue$ServerTimestampFieldValue`