### PR TITLE
Firestore onSnapshot update to support onError Callbacks.

### DIFF
--- a/docs/FIRESTORE.md
+++ b/docs/FIRESTORE.md
@@ -60,6 +60,29 @@ const unsubscribe = citiesCollection.onSnapshot((snapshot: firestore.QuerySnapsh
 
 // then after a while, to detach the listener:
 unsubscribe();
+
+/**
+ * If you pass in SnapshotOptions for the first parameter then your next should be onNext and
+ * onError if you want for the third parameter. If you pass onNext as the first parameter the
+ * second will be interpreted as onError callback. Note that you could pass onComplete, but
+ * it will never be called as stated by Firestore docs.
+ *
+ * onError callbacks are optional!
+ * onSnapshot(p1: SnapshotListenOptions|onNextCallback, p2?: onNextCallback | onErrorCallback, p3?: onErrorCallback?)
+ */
+const docRef: firestore.DocumentReference = firebase.firestore().collection("cities").doc("SF");
+docRef.onSnapshot(
+    {includeMetadataChanges: true},   // Comment out if you just want onNext && onError callbacks
+    (doc: firestore.DocumentSnapshot) => {
+
+      const source = doc.metadata.fromCache ? "local cache" : "server";
+      console.log("Data came from " + source);
+      console.log("Has pending writes? " + doc.metadata.hasPendingWrites);
+    },
+    (error: Error) => {
+      console.error(error);
+    }
+  );
 ```
 
 > Using **Observables**? [Check the example in the demo app](https://github.com/EddyVerbruggen/nativescript-plugin-firebase/blob/f6972433dea48bf1d342a6e4ef7f955dff341837/demo-ng/app/item/items.component.ts#L187-L198).

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -789,17 +789,25 @@ export namespace firestore {
 
   export interface DocumentReference {
     discriminator: "docRef";
+
     id: string;
+
     path: string;
+
     collection: (collectionPath: string) => CollectionReference;
+
     set: (document: any, options?: SetOptions) => Promise<void>;
+
     get: () => Promise<DocumentSnapshot>;
+
     update: (document: any) => Promise<void>;
+
     delete: () => Promise<void>;
 
-    onSnapshot(optionsOrCallback: SnapshotListenOptions | ((snapshot: DocumentSnapshot) => void), callback?: (snapshot: DocumentSnapshot) => void): () => void;
+    onSnapshot(optionsOrCallback: SnapshotListenOptions | ((snapshot: DocumentSnapshot) => void), callbackOrOnError?: (snapshot: DocumentSnapshot | Error) => void, onError?: (error: Error) => void): () => void;
 
     android?: any;
+
     ios?: any;
   }
 
@@ -812,7 +820,7 @@ export namespace firestore {
 
     limit(limit: number): Query;
 
-    onSnapshot(optionsOrCallback: SnapshotListenOptions | ((snapshot: QuerySnapshot) => void), callback?: (snapshot: QuerySnapshot) => void): () => void;
+    onSnapshot(optionsOrCallback: SnapshotListenOptions | ((snapshot: QuerySnapshot) => void), callbackOrOnError?: (snapshotOrError: QuerySnapshot | Error) => void, onError?: (error: Error) => void): () => void;
 
     startAt(snapshot: DocumentSnapshot): Query;
 


### PR DESCRIPTION
This PR updates Firestore: document + query onSnapshot so that it supports onError callbacks.

The changes are backwards compatible and allows users to optionally pass in onError() if they wish to handle errors that may occur.

Also fixes a crash that will occur if the first parameter passed to `onSnapshot` was type `firestore.SnapshotListenOptions` and no other parameters were passed in.