### PR TITLE
Add methods to set analytics session parameters

### DIFF
--- a/src/analytics/analytics.android.ts
+++ b/src/analytics/analytics.android.ts
@@ -171,3 +171,15 @@ export function setAnalyticsCollectionEnabled(enabled: boolean): void {
       appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
   ).setAnalyticsCollectionEnabled(enabled);
 }
+
+export function setMinimumSessionDuration(milliseconds: number): void {
+  com.google.firebase.analytics.FirebaseAnalytics.getInstance(
+      appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
+  ).setMinimumSessionDuration(milliseconds);
+}
+
+export function setSessionTimeoutDuration(milliseconds: number): void {
+  com.google.firebase.analytics.FirebaseAnalytics.getInstance(
+      appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
+  ).setSessionTimeoutDuration(milliseconds);
+}

--- a/src/analytics/analytics.android.ts
+++ b/src/analytics/analytics.android.ts
@@ -172,12 +172,6 @@ export function setAnalyticsCollectionEnabled(enabled: boolean): void {
   ).setAnalyticsCollectionEnabled(enabled);
 }
 
-export function setMinimumSessionDuration(milliseconds: number): void {
-  com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-      appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
-  ).setMinimumSessionDuration(milliseconds);
-}
-
 export function setSessionTimeoutDuration(milliseconds: number): void {
   com.google.firebase.analytics.FirebaseAnalytics.getInstance(
       appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()

--- a/src/analytics/analytics.d.ts
+++ b/src/analytics/analytics.d.ts
@@ -73,3 +73,7 @@ export declare function setUserProperty(options: SetUserPropertyOptions): Promis
 export declare function setScreenName(options: SetScreenNameOptions): Promise<void>;
 
 export declare function setAnalyticsCollectionEnabled(enabled: boolean): void;
+
+export declare function setMinimumSessionDuration(milliseconds: number): void;
+
+export declare function setSessionTimeoutDuration(milliseconds: number): void;

--- a/src/analytics/analytics.d.ts
+++ b/src/analytics/analytics.d.ts
@@ -74,6 +74,4 @@ export declare function setScreenName(options: SetScreenNameOptions): Promise<vo
 
 export declare function setAnalyticsCollectionEnabled(enabled: boolean): void;
 
-export declare function setMinimumSessionDuration(milliseconds: number): void;
-
 export declare function setSessionTimeoutDuration(milliseconds: number): void;

--- a/src/analytics/analytics.ios.ts
+++ b/src/analytics/analytics.ios.ts
@@ -216,3 +216,11 @@ export function setScreenName(options: SetScreenNameOptions): Promise<void> {
 export function setAnalyticsCollectionEnabled(enabled: boolean): void {
   FIRAnalyticsConfiguration.sharedInstance().setAnalyticsCollectionEnabled(enabled);
 }
+
+export function setMinimumSessionDuration(milliseconds: number): void {
+  FIRAnalyticsConfiguration.sharedInstance().setMinimumSessionInterval(milliseconds);
+}
+
+export function setSessionTimeoutDuration(milliseconds: number): void {
+  FIRAnalyticsConfiguration.sharedInstance().setSessionTimeoutInterval(milliseconds);
+}

--- a/src/analytics/analytics.ios.ts
+++ b/src/analytics/analytics.ios.ts
@@ -217,10 +217,6 @@ export function setAnalyticsCollectionEnabled(enabled: boolean): void {
   FIRAnalyticsConfiguration.sharedInstance().setAnalyticsCollectionEnabled(enabled);
 }
 
-export function setMinimumSessionDuration(milliseconds: number): void {
-  FIRAnalyticsConfiguration.sharedInstance().setMinimumSessionInterval(milliseconds);
-}
-
 export function setSessionTimeoutDuration(milliseconds: number): void {
   FIRAnalyticsConfiguration.sharedInstance().setSessionTimeoutInterval(milliseconds);
 }


### PR DESCRIPTION
In the Analytics module, add a method to set the delay before an analytics session starts :

```setMinimumSessionDuration(milliseconds: number): void;```

Source: [Android](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.html#setMinimumSessionDuration(long)) & [IOS](https://firebase.google.com/docs/reference/swift/firebasecore/api/reference/Classes/AnalyticsConfiguration#/c:objc(cs)FIRAnalyticsConfiguration(im)setMinimumSessionInterval:)

And another method to set the delay before an analytics session is finished : 

```setSessionTimeoutDuration(milliseconds: number): void;```

Source: [Android](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.html#setSessionTimeoutDuration(long)) & [IOS](https://firebase.google.com/docs/reference/swift/firebasecore/api/reference/Classes/AnalyticsConfiguration#/c:objc(cs)FIRAnalyticsConfiguration(im)setSessionTimeoutInterval:)
