### PR TITLE
Using Non-Firebase Push Messaging with other Firebase Services

### DIFF
--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -4574,7 +4574,7 @@ post_install do |installer|
 end`) + `
 
 # Firebase Cloud Messaging (FCM)
-` + (isSelected(result.messaging) ? `` : `#`) + `pod 'Firebase/Messaging'
+` + (isSelected(result.messaging) && !isSelected(result.external_messaging) ? `` : `#`) + `pod 'Firebase/Messaging'
 
 # Firebase In-App Messaging (supported on NativeScript 5.2+)
 ` + (isSelected(result.in_app_messaging) && supportsIOSModernBuildSystem ? `` : `#`) + `pod 'Firebase/InAppMessagingDisplay'


### PR DESCRIPTION
Adds the ability to have Non Firebase Push Messaging along with other Firebase services.

if `external_messaging` in `firebase.nativescript.json` is true, then it won't add the Firebase/Messaging iOS SDK. 

We keep `"messaging": true` in `firebase.nativescript.json` to enable Android push messaging.