### PR TITLE
[auth][web] - Add missing method getIdTokenResult()

### DIFF
--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -3,7 +3,7 @@ import {
   AddEventListenerResult,
   admob as firebaseAdMob,
   crashlytics as firebaseCrashlytics,
-  GetAuthTokenResult,
+  IdTokenResult,
   GetRemoteConfigResult,
   LogComplexEventTypeParameter,
   performance as firebasePerformance,
@@ -1026,7 +1026,7 @@ export class HelloWorldModel extends Observable {
               {
                 forceRefresh: false
               })
-              .then((result: GetAuthTokenResult) => console.log("Auth token retrieved: " + JSON.stringify(result)))
+              .then((result: IdTokenResult) => console.log("Auth token retrieved: " + JSON.stringify(result)))
               .catch(errorMessage => console.log("Auth token retrieval error: " + errorMessage));
         },
         errorMessage => {

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -743,7 +743,10 @@ firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<GetAuthTokenResult> 
             resolve({
               token: tokenResult.getToken(),
               claims: firebase.toJsObject(tokenResult.getClaims()),
-              signInProvider: tokenResult.getSignInProvider()
+              signInProvider: tokenResult.getSignInProvider(),
+              expirationTime: tokenResult.getExpirationTimestamp(),
+              issuedAtTime: tokenResult.getIssuedAtTimestamp(),
+              authTime: tokenResult.getAuthTimestamp()
             });
           }
         });
@@ -809,6 +812,11 @@ function toLoginResult(user, additionalUserInfo?): User {
     getIdToken: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
       firebase.getAuthToken({forceRefresh})
           .then((result: GetAuthTokenResult) => resolve(result.token))
+          .catch(reject);
+    }),
+    getIdTokenResult: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
+      firebase.getAuthToken({forceRefresh})
+          .then((result: GetAuthTokenResult) => resolve(result))
           .catch(reject);
     }),
     sendEmailVerification: (actionCodeSettings?: ActionCodeSettings) => firebase.sendEmailVerification(actionCodeSettings)

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -9,7 +9,7 @@ import {
   FBErrorData,
   firestore,
   GetAuthTokenOptions,
-  GetAuthTokenResult,
+  IdTokenResult,
   OnDisconnect as OnDisconnectBase, QueryOptions,
   User
 } from "./firebase";
@@ -732,7 +732,7 @@ firebase.unlink = providerId => {
   });
 };
 
-firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<GetAuthTokenResult> => {
+firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<IdTokenResult> => {
   return new Promise((resolve, reject) => {
     try {
       const firebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
@@ -811,12 +811,12 @@ function toLoginResult(user, additionalUserInfo?): User {
     },
     getIdToken: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
       firebase.getAuthToken({forceRefresh})
-          .then((result: GetAuthTokenResult) => resolve(result.token))
+          .then((result: IdTokenResult) => resolve(result.token))
           .catch(reject);
     }),
     getIdTokenResult: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
       firebase.getAuthToken({forceRefresh})
-          .then((result: GetAuthTokenResult) => resolve(result))
+          .then((result: IdTokenResult) => resolve(result))
           .catch(reject);
     }),
     sendEmailVerification: (actionCodeSettings?: ActionCodeSettings) => firebase.sendEmailVerification(actionCodeSettings)

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -204,10 +204,13 @@ export interface GetAuthTokenOptions {
   forceRefresh?: boolean;
 }
 
-export interface GetAuthTokenResult {
+export interface GetAuthTokenResult { // Need to rename to IdTokenResult for webAPI
   token: string;
   claims: { [key: string]: any; };
   signInProvider: string;
+  expirationTime: number;
+  issuedAtTime: number;
+  authTime: number;
 }
 
 export interface Provider {
@@ -356,6 +359,8 @@ export interface User {
   refreshToken?: string;
 
   getIdToken(forceRefresh?: boolean): Promise<string>;
+
+  getIdTokenResult(forceRefresh?: boolean): Promise<any>; // Returns GetAuthTokenResult, but we should rename to IdTokenResult to be web compatible
 
   sendEmailVerification(actionCodeSettings?: ActionCodeSettings): Promise<void>;
 }

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -204,7 +204,7 @@ export interface GetAuthTokenOptions {
   forceRefresh?: boolean;
 }
 
-export interface GetAuthTokenResult { // Need to rename to IdTokenResult for webAPI
+export interface IdTokenResult {
   token: string;
   claims: { [key: string]: any; };
   signInProvider: string;
@@ -360,7 +360,7 @@ export interface User {
 
   getIdToken(forceRefresh?: boolean): Promise<string>;
 
-  getIdTokenResult(forceRefresh?: boolean): Promise<any>; // Returns GetAuthTokenResult, but we should rename to IdTokenResult to be web compatible
+  getIdTokenResult(forceRefresh?: boolean): Promise<IdTokenResult>;
 
   sendEmailVerification(actionCodeSettings?: ActionCodeSettings): Promise<void>;
 }

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -690,7 +690,12 @@ function toLoginResult(user, additionalUserInfo?: FIRAdditionalUserInfo): User {
     getIdToken: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
       firebase.getAuthToken({forceRefresh})
           .then((result: GetAuthTokenResult) => resolve(result.token))
-          .catch(reject)
+          .catch(reject);
+    }),
+    getIdTokenResult: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
+      firebase.getAuthToken({forceRefresh})
+          .then((result: GetAuthTokenResult) => resolve(result))
+          .catch(reject);
     }),
     sendEmailVerification: (actionCodeSettings?: ActionCodeSettings) => firebase.sendEmailVerification(actionCodeSettings)
   };
@@ -725,7 +730,10 @@ firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<GetAuthTokenResult> 
             resolve({
               token: result.token,
               claims: firebaseUtils.toJsObject(result.claims),
-              signInProvider: result.signInProvider
+              signInProvider: result.signInProvider,
+              expirationTime: firebaseUtils.toJsObject(result.expirationDate),
+              issuedAtTime: firebaseUtils.toJsObject(result.issuedAtDate),
+              authTime: firebaseUtils.toJsObject(result.authDate)
             });
           }
         });

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -5,7 +5,7 @@ import {
   FBDataSingleEvent,
   firestore,
   GetAuthTokenOptions,
-  GetAuthTokenResult,
+  IdTokenResult,
   OnDisconnect as OnDisconnectBase, QueryOptions,
   User
 } from "./firebase";
@@ -689,12 +689,12 @@ function toLoginResult(user, additionalUserInfo?: FIRAdditionalUserInfo): User {
     },
     getIdToken: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
       firebase.getAuthToken({forceRefresh})
-          .then((result: GetAuthTokenResult) => resolve(result.token))
+          .then((result: IdTokenResult) => resolve(result.token))
           .catch(reject);
     }),
     getIdTokenResult: (forceRefresh?: boolean) => new Promise((resolve, reject) => {
       firebase.getAuthToken({forceRefresh})
-          .then((result: GetAuthTokenResult) => resolve(result))
+          .then((result: IdTokenResult) => resolve(result))
           .catch(reject);
     }),
     sendEmailVerification: (actionCodeSettings?: ActionCodeSettings) => firebase.sendEmailVerification(actionCodeSettings)
@@ -712,7 +712,7 @@ function toLoginResult(user, additionalUserInfo?: FIRAdditionalUserInfo): User {
   return loginResult;
 }
 
-firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<GetAuthTokenResult> => {
+firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<IdTokenResult> => {
   return new Promise((resolve, reject) => {
     try {
       const fAuth = FIRAuth.auth();


### PR DESCRIPTION
This PR adds `getIdTokenResult()` which builds on: https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/1189

To make these changes backwards compatible I did not rename the interface `GetAuthTokenResult` to `IdTokenResult`, but we definitely should to follow web standards.

https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult