### PR TITLE
fix: onAdClosed it's never fired

### DIFF
--- a/src/admob/admob.ios.ts
+++ b/src/admob/admob.ios.ts
@@ -98,10 +98,10 @@ export function preloadInterstitial(arg: InterstitialOptions): Promise<any> {
             } else {
               resolve();
             }
-            CFRelease(delegate);
-            delegate = undefined;
           }, () => {
             arg.onAdClosed && arg.onAdClosed();
+            CFRelease(delegate);
+            delegate = undefined;
           });
 
       CFRetain(delegate);


### PR DESCRIPTION
This PR fixes the callback onAdClosed, that it's not working with `preloadInterstitial` on ios because the delegate is cleaned as soon the ad it's loaded so the onAdCloseCallback will never be fired