### PR TITLE
fix: preloadInterstitial promise doesn't resolve for a second ad

### DIFF
--- a/src/admob/admob.android.ts
+++ b/src/admob/admob.android.ts
@@ -98,13 +98,17 @@ export function preloadInterstitial(arg: InterstitialOptions): Promise<any> {
       firebase.admob.interstitialView = new com.google.android.gms.ads.InterstitialAd(activity);
       firebase.admob.interstitialView.setAdUnitId(settings.androidInterstitialId);
 
+      // need these to support preloadInterstitial more than once
+      this.resolve = resolve;
+      this.reject = reject;
+
       // Interstitial ads must be loaded before they can be shown, so adding a listener
       const InterstitialAdListener = com.google.android.gms.ads.AdListener.extend({
         onAdLoaded: () => {
-          resolve();
+          this.resolve();
         },
         onAdFailedToLoad: errorCode => {
-          reject(errorCode);
+          this.reject(errorCode);
         },
         onAdClosed: () => {
           if (firebase.admob.interstitialView) {


### PR DESCRIPTION
This PR fixes the preloadInterstitial promise, that it's not working on android because of an issue related to JavaScript closures that not allow resolve multiple promises, it's the same issue that https://github.com/EddyVerbruggen/nativescript-plugin-firebase/blob/master/src/admob/admob.android.ts#L30