### PR TITLE
This would fix the issue #1222 with deprecated currentContext

### DIFF
--- a/src/analytics/analytics.android.ts
+++ b/src/analytics/analytics.android.ts
@@ -28,7 +28,7 @@ export function logEvent(options: LogEventOptions): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
       ).logEvent(options.key, bundle);
 
       resolve();

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -314,7 +314,7 @@ firebase.init = arg => {
       initializeArguments = arg;
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.currentContext || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
       ).setAnalyticsCollectionEnabled(arg.analyticsCollectionEnabled !== false);
 
       if (typeof (com.google.firebase.database) !== "undefined" && typeof (com.google.firebase.database.ServerValue) !== "undefined") {
@@ -1114,7 +1114,7 @@ firebase.login = arg => {
 
         const signInIntent = com.google.android.gms.auth.api.Auth.GoogleSignInApi.getSignInIntent(firebase._mGoogleApiClient);
 
-        appModule.android.currentContext.startActivityForResult(signInIntent, GOOGLE_SIGNIN_INTENT_ID);
+        appModule.android.context.startActivityForResult(signInIntent, GOOGLE_SIGNIN_INTENT_ID);
 
         const callback = (eventData: AndroidActivityResultEventData) => {
           if (eventData.requestCode === GOOGLE_SIGNIN_INTENT_ID) {


### PR DESCRIPTION
Not sure if it has compability issues with lower nativescript versions though, if yes, I could add some handling code. It works on my system with nativescript 

```
✔ Component nativescript has 5.3.1 version and is up to date.
✔ Component tns-core-modules has 5.3.1 version and is up to date.
✔ Component tns-android has 5.3.1 version and is up to date.
```

https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/1222