### PR TITLE
fix: use string concatenation instead of format

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -1115,10 +1115,10 @@ task copyMetadata {
     copy {
       if (!project.mergedAssetsOutputPath) {
         // mergedAssetsOutputPath not found fallback to the default value for android gradle plugin 3.4.0
-        project.ext.mergedAssetsOutputPath = "$projectDir/build/intermediates/assets/\${project.selectedBuildType}/out"
+        project.ext.mergedAssetsOutputPath = "$projectDir/build/intermediates/assets/" + project.selectedBuildType + "/out"
       }
-        from "$projectDir/src/main/assets/metadata"
-      into "\${project.mergedAssetsOutputPath}/metadata"
+      from "$projectDir/src/main/assets/metadata"
+      into project.mergedAssetsOutputPath + "/metadata"
     }
   }
 }\`;

--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -5276,7 +5276,7 @@ task copyMetadata {
       if (variant.buildType.name == project.selectedBuildType) {
         def task = provider.get();
         for (File file : task.getOutputs().getFiles()) {
-          if(!file.getPath().contains("/incremental/")) {
+          if (!file.getPath().contains("/incremental/")) {
             project.ext.mergedAssetsOutputPath = file.getPath()
           }
         }
@@ -5285,12 +5285,12 @@ task copyMetadata {
   }
   doLast {
     copy {
-      if(!project.mergedAssetsOutputPath) {
+      if (!project.mergedAssetsOutputPath) {
         // mergedAssetsOutputPath not found fallback to the default value for android gradle plugin 3.4.0
-        project.ext.mergedAssetsOutputPath = "$projectDir/build/intermediates/assets/\${project.selectedBuildType}/out"
+        project.ext.mergedAssetsOutputPath = "$projectDir/build/intermediates/assets/" + project.selectedBuildType + "/out"
       }
       from "$projectDir/src/main/assets/metadata"
-      into "\${project.mergedAssetsOutputPath}/metadata"
+      into project.mergedAssetsOutputPath + "/metadata"
     }
   }
 }\`;


### PR DESCRIPTION
The problem with the `project is not defined` comes because of using ${} which has to be escaped twice, because we are doing string replace twice, but to avoid this I've changed it with using string concatenation instead of string format.