### PR TITLE
fix: make the plugin androidx compatible

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -268,6 +268,7 @@ firebase.toJsObject = javaObj => {
       break;
     case 'android.util.ArrayMap':
     case 'android.support.v4.util.ArrayMap':
+    case 'androidx.collection.ArrayMap':
       node = {};
       for (let i = 0; i < javaObj.size(); i++) {
         node[javaObj.keyAt(i)] = firebase.toJsObject(javaObj.valueAt(i));

--- a/src/messaging/messaging.android.ts
+++ b/src/messaging/messaging.android.ts
@@ -4,7 +4,8 @@ import * as application from "tns-core-modules/application/application";
 import { PushNotificationModel } from "./messaging.ios";
 import { MessagingOptions } from "../firebase";
 
-declare const android, com, org: any;
+declare const android, com, org, global: any;
+const NotificationManagerCompatClass = useAndroidX() ? global.androidx.core.app.NotificationManagerCompat : android.support.v4.app.NotificationManagerCompat;
 
 let _launchNotification = null;
 let _senderId: string = null;
@@ -241,11 +242,15 @@ export function unsubscribeFromTopic(topicName) {
   });
 }
 
+function useAndroidX() {
+  return global.androidx && global.androidx.appcompat;
+}
+
 export function areNotificationsEnabled() {
   const androidSdkVersion = android.os.Build.VERSION.SDK_INT;
 
   if (androidSdkVersion >= 24) { // android.os.Build.VERSION_CODES.N
-    return android.support.v4.app.NotificationManagerCompat.from(application.android.context).areNotificationsEnabled();
+    return NotificationManagerCompatClass.from(application.android.context).areNotificationsEnabled();
   } else {
     console.log("NotificationManagerCompat.areNotificationsEnabled() is not supported in Android SDK VERSION " + androidSdkVersion);
     return true;

--- a/src/mlkit/mlkit-cameraview.android.ts
+++ b/src/mlkit/mlkit-cameraview.android.ts
@@ -2,6 +2,8 @@ import * as application from "tns-core-modules/application";
 import * as utils from "tns-core-modules/utils/utils";
 import { MLKitCameraView as MLKitCameraViewBase } from "./mlkit-cameraview-common";
 
+declare const global: any;
+const ActivityCompatClass = useAndroidX() ? global.androidx.core.app.ActivityCompat : android.support.v4.app.ActivityCompat;
 const CAMERA_PERMISSION_REQUEST_CODE = 502;
 
 // declare const com, android: any;
@@ -15,6 +17,10 @@ class SizePair {
     width: number;
     height: number;
   };
+}
+
+function useAndroidX() {
+  return global.androidx && global.androidx.appcompat;
 }
 
 export abstract class MLKitCameraView extends MLKitCameraViewBase {
@@ -78,7 +84,7 @@ export abstract class MLKitCameraView extends MLKitCameraViewBase {
         application.android.on(application.AndroidApplication.activityRequestPermissionsEvent, permissionCb);
 
         // invoke the permission dialog
-        (android.support.v4.app.ActivityCompat as any).requestPermissions(
+        ActivityCompatClass.requestPermissions(
             application.android.foregroundActivity || application.android.startActivity,
             [android.Manifest.permission.CAMERA],
             CAMERA_PERMISSION_REQUEST_CODE);


### PR DESCRIPTION
As this plugin uses the old Android Support Libraries, it will not be compatible with the upcoming NativeScript 6.0 release which will use [AndroidX by default](https://www.nativescript.org/blog/support-for-androidx-in-nativescript). The changes from this PR, make the plugin compatible with the AndroidX library (NS 6.0) and with the old libraries (NS before 6.0).