### PR TITLE
feat: migrate hooks to NativeScript v6.0.0

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -513,9 +513,9 @@ const string3 = \`
 \`;
 
 module.exports = function($logger, $projectData, hookArgs) {
-  const platform = hookArgs.platform.toLowerCase();
+  const platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase();
   return new Promise(function(resolve, reject) {
-    const isNativeProjectPrepared = !hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare;
+    const isNativeProjectPrepared = hookArgs.prepareData ? (!hookArgs.prepareData.nativePrepare || !hookArgs.prepareData.nativePrepare.skipNativePrepare)) : (!hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare);
     if (isNativeProjectPrepared) {
       try {
         if (platform === 'ios') {
@@ -615,9 +615,9 @@ function writeBuildscriptHookForFirestore(enable) {
 const path = require('path');
 
 module.exports = function($logger, $projectData, hookArgs) {
-  const platform = hookArgs.platform.toLowerCase();
+  const platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase();
   return new Promise(function(resolve, reject) {
-    const isNativeProjectPrepared = !hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare;
+    const isNativeProjectPrepared = hookArgs.prepareData ? (!hookArgs.prepareData.nativePrepare || !hookArgs.prepareData.nativePrepare.skipNativePrepare) : (!hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare);
     if (isNativeProjectPrepared) {
       try {
         if (platform !== 'ios') {
@@ -816,22 +816,23 @@ module.exports = function($logger, $projectData, hookArgs) {
 return new Promise(function(resolve, reject) {
 
         /* Decide whether to prepare for dev or prod environment */
-
-        var isReleaseBuild = (hookArgs.appFilesUpdaterOptions && hookArgs.appFilesUpdaterOptions.release) ? true : false;
+        var isReleaseBuild = (hookArgs.appFilesUpdaterOptions || hookArgs.prepareData).release;
         var validProdEnvs = ['prod','production'];
         var isProdEnv = false; // building with --env.prod or --env.production flag
+        var env = (hookArgs.platformSpecificData || hookArgs.prepareData).env;
 
-        if (hookArgs.platformSpecificData.env) {
-            Object.keys(hookArgs.platformSpecificData.env).forEach((key) => {
+        if (env) {
+            Object.keys(env).forEach((key) => {
                 if (validProdEnvs.indexOf(key)>-1) { isProdEnv=true; }
             });
         }
 
         var buildType = isReleaseBuild || isProdEnv ? 'production' : 'development';
+        var platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase();
 
         /* Create info file in platforms dir so we can detect changes in environment and force prepare if needed */
 
-        var npfInfoPath = path.join($projectData.platformsDir, hookArgs.platform.toLowerCase(), ".pluginfirebaseinfo");
+        var npfInfoPath = path.join($projectData.platformsDir, platform, ".pluginfirebaseinfo");
         var npfInfo = {
             buildType: buildType,
         };
@@ -844,7 +845,7 @@ return new Promise(function(resolve, reject) {
 
         /* Handle preparing of Google Services files */
 
-        if (hookArgs.platform.toLowerCase() === 'android') {
+        if (platform === 'android') {
             var destinationGoogleJson = path.join($projectData.platformsDir, "android", "app", "google-services.json");
             var destinationGoogleJsonAlt = path.join($projectData.platformsDir, "android", "google-services.json");
             var sourceGoogleJson = path.join($projectData.appResourcesDirectoryPath, "Android", "google-services.json");
@@ -871,7 +872,7 @@ return new Promise(function(resolve, reject) {
                 $logger.warn("Unable to copy google-services.json.");
                 reject();
             }
-        } else if (hookArgs.platform.toLowerCase() === 'ios') {
+        } else if (platform === 'ios') {
             // we have copied our GoogleService-Info.plist during before-checkForChanges hook, here we delete it to avoid changes in git
             var destinationGooglePlist = path.join($projectData.appResourcesDirectoryPath, "iOS", "GoogleService-Info.plist");
             var sourceGooglePlistProd = path.join($projectData.appResourcesDirectoryPath, "iOS", "GoogleService-Info.plist.prod");
@@ -916,16 +917,16 @@ return new Promise(function(resolve, reject) {
 var path = require("path");
 var fs = require("fs");
 
-module.exports = function($logger, $projectData, hookArgs) {
+module.exports = function($logger, hookArgs) {
     return new Promise(function(resolve, reject) {
 
         /* Decide whether to prepare for dev or prod environment */
 
-        var isReleaseBuild = hookArgs['checkForChangesOpts']['projectData']['$options']['argv']['release'] || false;
+        var isReleaseBuild = !!((hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectChangesOptions) || hookArgs.prepareData).release;
         var validProdEnvs = ['prod','production'];
         var isProdEnv = false; // building with --env.prod or --env.production flag
 
-        var env = hookArgs['checkForChangesOpts']['projectData']['$options']['argv']['env'];
+        var env = ((hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectData && hookArgs.checkForChangesOpts.projectData.$options && hookArgs.checkForChangesOpts.projectData.$options.argv) || hookArgs.prepareData).env;
         if (env) {
             Object.keys(env).forEach((key) => {
                 if (validProdEnvs.indexOf(key)>-1) { isProdEnv=true; }
@@ -939,9 +940,10 @@ module.exports = function($logger, $projectData, hookArgs) {
             for which environment {development|prod} the project was prepared. If needed, we delete the NS .nsprepareinfo
             file so we force a new prepare
         */
-        var platform = hookArgs['checkForChangesOpts']['platform'].toLowerCase(); // ios | android
-        var platformsDir = hookArgs['checkForChangesOpts']['projectData']['platformsDir'];
-        var appResourcesDirectoryPath = hookArgs['checkForChangesOpts']['projectData']['appResourcesDirectoryPath'];
+        var platform = (hookArgs.checkForChangesOpts || hookArgs.platformData).platform.toLowerCase();
+        var projectData = (hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectData) || hookArgs.projectData;
+        var platformsDir = projectData.platformsDir;
+        var appResourcesDirectoryPath = projectData.appResourcesDirectoryPath;
         var forcePrepare = true; // whether to force NS to run prepare, defaults to true
         var npfInfoPath = path.join(platformsDir, platform, ".pluginfirebaseinfo");
         var nsPrepareInfoPath = path.join(platformsDir, platform, ".nsprepareinfo");

--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -513,7 +513,8 @@ const string3 = \`
 \`;
 
 module.exports = function($logger, $projectData, hookArgs) {
-  const platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase();
+  const platformFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
+  const platform = (platformFromHookArgs  || '').toLowerCase();
   return new Promise(function(resolve, reject) {
     const isNativeProjectPrepared = hookArgs.prepareData ? (!hookArgs.prepareData.nativePrepare || !hookArgs.prepareData.nativePrepare.skipNativePrepare)) : (!hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare);
     if (isNativeProjectPrepared) {
@@ -615,7 +616,8 @@ function writeBuildscriptHookForFirestore(enable) {
 const path = require('path');
 
 module.exports = function($logger, $projectData, hookArgs) {
-  const platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase();
+  const platformFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
+  const platform = (platformFromHookArgs  || '').toLowerCase();
   return new Promise(function(resolve, reject) {
     const isNativeProjectPrepared = hookArgs.prepareData ? (!hookArgs.prepareData.nativePrepare || !hookArgs.prepareData.nativePrepare.skipNativePrepare) : (!hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare);
     if (isNativeProjectPrepared) {
@@ -828,7 +830,8 @@ return new Promise(function(resolve, reject) {
         }
 
         var buildType = isReleaseBuild || isProdEnv ? 'production' : 'development';
-        var platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase();
+        const platformFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
+        const platform = (platformFromHookArgs  || '').toLowerCase();
 
         /* Create info file in platforms dir so we can detect changes in environment and force prepare if needed */
 

--- a/src/scripts/entitlements-after-prepare.js
+++ b/src/scripts/entitlements-after-prepare.js
@@ -23,8 +23,8 @@ function patchPodsBundlesPlugins(podsFile) {
   }
 }
 
-module.exports = function (logger, platformsData, projectData, hookArgs) {
-  var platform = hookArgs.platform.toLowerCase(),
+module.exports = function (projectData, hookArgs) {
+  var platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)).toLowerCase(),
       appResourcesDirectoryPath = projectData.appResourcesDirectoryPath,
       entitlementsFile = path.join(appResourcesDirectoryPath, "iOS", projectData.projectName + ".entitlements"),
       projectRoot = path.join(projectData.platformsDir, "ios"),

--- a/src/scripts/entitlements-before-prepare.js
+++ b/src/scripts/entitlements-before-prepare.js
@@ -1,10 +1,10 @@
 var fs = require('fs');
 var path = require('path');
 
-module.exports = function (logger, platformsData, projectData, hookArgs) {
-  var platform = hookArgs.platform.toLowerCase(),
-      appResourcesDirectoryPath = projectData.appResourcesDirectoryPath,
-      entitlementsFile = path.join(appResourcesDirectoryPath, "iOS", projectData.projectName + ".entitlements"),
+module.exports = function (hookArgs, $projectData) {
+  var platform = (hookArgs.platform || hookArgs.prepareData.platform).toLowerCase(),
+      appResourcesDirectoryPath = $projectData.appResourcesDirectoryPath,
+      entitlementsFile = path.join(appResourcesDirectoryPath, "iOS", $projectData.projectName + ".entitlements"),
       platformResourcesDirectory = path.join(appResourcesDirectoryPath, 'iOS');
 
   // look for both <projectname.entitlements and app.entitlements
@@ -18,7 +18,7 @@ module.exports = function (logger, platformsData, projectData, hookArgs) {
       try {
         var buildData = fs.readFileSync(target).toString();
         if (!buildData.toString().match(/^\s*CODE_SIGN_ENTITLEMENTS/mg)) {
-          fs.appendFileSync(target, '\nCODE_SIGN_ENTITLEMENTS = ' + path.join(projectData.projectName, projectData.projectName + '.entitlements'));
+          fs.appendFileSync(target, '\nCODE_SIGN_ENTITLEMENTS = ' + path.join($projectData.projectName, $projectData.projectName + '.entitlements'));
         }
       } catch (error) {
         console.log("Error in hook 'entitlements-before-prepare.js': " + error);

--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -4687,7 +4687,7 @@ const string3 = \`
 module.exports = function($logger, $projectData, hookArgs) {
   const platform = hookArgs.platform.toLowerCase();
   return new Promise(function(resolve, reject) {
-    const isNativeProjectPrepared = !hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare;
+    const isNativeProjectPrepared = hookArgs.prepareData ? (!hookArgs.prepareData.nativePrepare || !hookArgs.prepareData.nativePrepare.skipNativePrepare) : (!hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare);
     if (isNativeProjectPrepared) {
       try {
         if (platform === 'ios') {
@@ -4789,7 +4789,7 @@ const path = require('path');
 module.exports = function($logger, $projectData, hookArgs) {
   const platform = hookArgs.platform.toLowerCase();
   return new Promise(function(resolve, reject) {
-    const isNativeProjectPrepared = !hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare;
+    const isNativeProjectPrepared = hookArgs.prepareData ? (!hookArgs.prepareData.nativePrepare || !hookArgs.prepareData.nativePrepare.skipNativePrepare) : (!hookArgs.nativePrepare || !hookArgs.nativePrepare.skipNativePrepare);
     if (isNativeProjectPrepared) {
       try {
         if (platform !== 'ios') {
@@ -4979,7 +4979,7 @@ function writeGoogleServiceCopyHook() {
   console.log("Install google-service.json after-prepare copy hook.");
   try {
     var afterPrepareScriptContent =
-        `
+`
 var path = require("path");
 var fs = require("fs");
 
@@ -4988,22 +4988,23 @@ module.exports = function($logger, $projectData, hookArgs) {
 return new Promise(function(resolve, reject) {
 
         /* Decide whether to prepare for dev or prod environment */
-
-        var isReleaseBuild = (hookArgs.appFilesUpdaterOptions && hookArgs.appFilesUpdaterOptions.release) ? true : false;
+        var isReleaseBuild = !!(hookArgs.appFilesUpdaterOptions || hookArgs.prepareData).release;
         var validProdEnvs = ['prod','production'];
         var isProdEnv = false; // building with --env.prod or --env.production flag
+        var env = (hookArgs.platformSpecificData || hookArgs.prepareData).env;
 
-        if (hookArgs.platformSpecificData.env) {
-            Object.keys(hookArgs.platformSpecificData.env).forEach((key) => {
+        if (env) {
+            Object.keys(env).forEach((key) => {
                 if (validProdEnvs.indexOf(key)>-1) { isProdEnv=true; }
             });
         }
 
         var buildType = isReleaseBuild || isProdEnv ? 'production' : 'development';
+        var platform = (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform) || '').toLowerCase();
 
         /* Create info file in platforms dir so we can detect changes in environment and force prepare if needed */
 
-        var npfInfoPath = path.join($projectData.platformsDir, hookArgs.platform.toLowerCase(), ".pluginfirebaseinfo");
+        var npfInfoPath = path.join($projectData.platformsDir, platform, ".pluginfirebaseinfo");
         var npfInfo = {
             buildType: buildType,
         };
@@ -5016,7 +5017,7 @@ return new Promise(function(resolve, reject) {
 
         /* Handle preparing of Google Services files */
 
-        if (hookArgs.platform.toLowerCase() === 'android') {
+        if (platform === 'android') {
             var destinationGoogleJson = path.join($projectData.platformsDir, "android", "app", "google-services.json");
             var destinationGoogleJsonAlt = path.join($projectData.platformsDir, "android", "google-services.json");
             var sourceGoogleJson = path.join($projectData.appResourcesDirectoryPath, "Android", "google-services.json");
@@ -5043,7 +5044,7 @@ return new Promise(function(resolve, reject) {
                 $logger.warn("Unable to copy google-services.json.");
                 reject();
             }
-        } else if (hookArgs.platform.toLowerCase() === 'ios') {
+        } else if (platform === 'ios') {
             // we have copied our GoogleService-Info.plist during before-checkForChanges hook, here we delete it to avoid changes in git
             var destinationGooglePlist = path.join($projectData.appResourcesDirectoryPath, "iOS", "GoogleService-Info.plist");
             var sourceGooglePlistProd = path.join($projectData.appResourcesDirectoryPath, "iOS", "GoogleService-Info.plist.prod");
@@ -5062,6 +5063,7 @@ return new Promise(function(resolve, reject) {
     });
 };
 `;
+
     var scriptPath = path.join(appRoot, "hooks", "after-prepare", "firebase-copy-google-services.js");
     var afterPrepareDirPath = path.dirname(scriptPath);
     var hooksDirPath = path.dirname(afterPrepareDirPath);
@@ -5093,11 +5095,11 @@ module.exports = function($logger, $projectData, hookArgs) {
 
         /* Decide whether to prepare for dev or prod environment */
 
-        var isReleaseBuild = hookArgs['checkForChangesOpts']['projectData']['$options']['argv']['release'] || false;
+        var isReleaseBuild = !!((hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectChangesOptions) || hookArgs.prepareData).release;
         var validProdEnvs = ['prod','production'];
         var isProdEnv = false; // building with --env.prod or --env.production flag
 
-        var env = hookArgs['checkForChangesOpts']['projectData']['$options']['argv']['env'];
+        var env = ((hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectData && hookArgs.checkForChangesOpts.projectData.$options && hookArgs.checkForChangesOpts.projectData.$options.argv) || hookArgs.prepareData).env;
         if (env) {
             Object.keys(env).forEach((key) => {
                 if (validProdEnvs.indexOf(key)>-1) { isProdEnv=true; }
@@ -5111,9 +5113,9 @@ module.exports = function($logger, $projectData, hookArgs) {
             for which environment {development|prod} the project was prepared. If needed, we delete the NS .nsprepareinfo
             file so we force a new prepare
         */
-        var platform = hookArgs['checkForChangesOpts']['platform'].toLowerCase(); // ios | android
-        var platformsDir = hookArgs['checkForChangesOpts']['projectData']['platformsDir'];
-        var appResourcesDirectoryPath = hookArgs['checkForChangesOpts']['projectData']['appResourcesDirectoryPath'];
+        var platform = (hookArgs.checkForChangesOpts || hookArgs.prepareData).platform.toLowerCase();
+        var platformsDir = $projectData.platformsDir;
+        var appResourcesDirectoryPath = $projectData.appResourcesDirectoryPath;
         var forcePrepare = true; // whether to force NS to run prepare, defaults to true
         var npfInfoPath = path.join(platformsDir, platform, ".pluginfirebaseinfo");
         var nsPrepareInfoPath = path.join(platformsDir, platform, ".nsprepareinfo");


### PR DESCRIPTION
In NativeScript 6.0.0 there's a major refactoring in CLI that will require changes in most of the plugin hooks.
The major changes are the hookArgs injected by CLI for each hook - they are changed, so some of the properties used from them, should be taken from different property.
The other major change is the injected data - in the function used as hook, you can use any service registered in CLI's bootstrap and CLI will pass it to the hook.
Several of the services are now renamed or deleted, so hooks using them should be migrated. Such service is platformsData.
The last major change is that some logger methods are deleted (they've been deprecated).

The current PR makes the hooks of this plugin compatible with the both 6.0.0 and old releases of NativeScript.