### PR TITLE
update postinstall.js to support  Xcode 10

### DIFF
--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -4699,7 +4699,11 @@ module.exports = function($logger, $projectData, hookArgs) {
           if (fs.existsSync(xcodeProjectPath)) {
             var xcodeProject = xcode.project(xcodeProjectPath);
             xcodeProject.parseSync();
-            var options = { shellPath: '/bin/sh', shellScript: '\"\${PODS_ROOT}/Fabric/run\"' };
+	    // Xcode 10 require input File Field set to $(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)
+	    // see https://firebase.google.com/docs/crashlytics/get-started
+            var options = { shellPath: '/bin/sh', shellScript: '\"\${PODS_ROOT}/Fabric/run\"',
+			    inputPaths: ['"\$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)\"']
+			};
             xcodeProject.addBuildPhase(
               [], 'PBXShellScriptBuildPhase', 'Configure Crashlytics', undefined, options
             ).buildPhase;


### PR DESCRIPTION
Xcode 10 require to have input file field set to point to info.plist file
see https://firebase.google.com/docs/crashlytics/get-started

Have not checked whether it still works with Xcode 9 base Builds
On My machine whenever i build project new build phase Configure Crashlytics added in XcodeProject file