### PR TITLE
Use instance of `FirebaseStorage` instead of ReferenceFromUrl

### DIFF
--- a/src/storage/storage.android.ts
+++ b/src/storage/storage.android.ts
@@ -21,7 +21,7 @@ function getStorageRef(reject, arg) {
     return;
   }
 
-  return arg.bucket ? com.google.firebase.storage.FirebaseStorage.getInstance().getReferenceFromUrl(arg.bucket) : firebase.storageBucket;
+  return arg.bucket ? com.google.firebase.storage.FirebaseStorage.getInstance(arg.bucket).getReference() : firebase.storageBucket;
 }
 
 export function uploadFile(arg: UploadFileOptions): Promise<UploadFileResult> {


### PR DESCRIPTION
Using a reference from the default instance does not allow to use other storage bucket than the default.
Changes made as documented: https://firebase.google.com/docs/storage/android/start#use_multiple_storage_buckets

Fixes #1298