### PR TITLE
fix: parse correctly CLI's version

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -4,7 +4,15 @@ var prompt = require('prompt-lite');
 
 const { execSync } = require('child_process');
 const semver = require('semver');
-const tnsVersionFull = execSync('tns --version', { encoding: 'ascii'});
+// In case the current Node.js version is not supported by CLI, a warning in `tns --version` output is shown.
+// Sample output:
+//
+/*Support for Node.js ^8.0.0 is deprecated and will be removed in one of the next releases of NativeScript. Please, upgrade to the latest Node.js LTS version.
+
+6.0.0
+*/
+// Extract the actual version (6.0.0) from it.
+const tnsVersionFull = (execSync('tns --version', { encoding: 'ascii'}).match(/^(?:\d+\.){2}\d+.*?$/m) || [])[0];
 
 // iOS modern build system is supported from version NativeScript-CLI version 5.2.0
 const supportsIOSModernBuildSystem = tnsVersionFull.indexOf("5.2.0-") > -1 || semver.gte(tnsVersionFull, "5.2.0");

--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -2251,7 +2251,7 @@ function coerce(version) {
   if (match == null)
     return null;
 
-  return parse((match[1] || '0') + '.' + (match[2] || '0') + '.' + (match[3] || '0')); 
+  return parse((match[1] || '0') + '.' + (match[2] || '0') + '.' + (match[3] || '0'));
 }
 
 
@@ -4176,7 +4176,15 @@ var prompt = __webpack_require__(/*! prompt-lite */ 1);
 
 const { execSync } = __webpack_require__(/*! child_process */ 3);
 const semver = __webpack_require__(/*! semver */ 2);
-const tnsVersionFull = execSync('tns --version', { encoding: 'ascii'});
+// In case the current Node.js version is not supported by CLI, a warning in `tns --version` output is shown.
+// Sample output:
+//
+/*Support for Node.js ^8.0.0 is deprecated and will be removed in one of the next releases of NativeScript. Please, upgrade to the latest Node.js LTS version.
+
+6.0.0
+*/
+// Extract the actual version (6.0.0) from it.
+const tnsVersionFull = (execSync('tns --version', { encoding: 'ascii'}).match(/^(?:\d+\.){2}\d+.*?$/m) || [])[0];
 
 // iOS modern build system is supported from version NativeScript-CLI version 5.2.0
 const supportsIOSModernBuildSystem = tnsVersionFull.indexOf("5.2.0-") > -1 || semver.gte(tnsVersionFull, "5.2.0");


### PR DESCRIPTION
In case the current Node.js version is not officialy supported by NativeScript CLI, i.e. its new and it is not verified or support for it is deprecated, `tns --version`'s ouput contains warning.
Extract the actual version from the output no matter if there's a warning or not.