### PR TITLE
Fixing dynamicLink crash

### DIFF
--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -198,7 +198,7 @@ firebase.addAppDelegateMethods = appDelegate => {
 
         } else {
           result = FIRDynamicLinks.dynamicLinks().handleUniversalLinkCompletion(userActivity.webpageURL, (dynamicLink, error) => {
-            if (dynamicLink.url !== null) {
+            if (dynamicLink !== null && dynamicLink.url !== null) {
               if (firebase._dynamicLinkCallback) {
                 firebase._dynamicLinkCallback({
                   url: dynamicLink.url.absoluteString,


### PR DESCRIPTION
fixing crash if firebase returns a null dynamic link in its completion handler when handling dynamic links