### PR TITLE
Update firebase.android.ts

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -299,7 +299,7 @@ firebase.init = arg => {
       arg = arg || {};
       initializeArguments = arg;
 
-      if (typeof (com.google.firebase.analytics) === "undefined") {
+      if (typeof (com.google.firebase.analytics) !== "undefined") {
         com.google.firebase.analytics.FirebaseAnalytics.getInstance(
             appModule.android.context || com.tns.NativeScriptApplication.getInstance()
         ).setAnalyticsCollectionEnabled(arg.analyticsCollectionEnabled !== false);


### PR DESCRIPTION
Line 302: Replace '===' with '!=='?
Code causes error if analytics disabled.
Is this an error or should 'com.google.firebase.analytics.FirebaseAnalytics' be defined within the condition before using 'setAnalyticsCollectionEnabled'?