### PR TITLE
getFunctions should have had the region as its argument on iOS

### DIFF
--- a/src/functions/functions.ios.ts
+++ b/src/functions/functions.ios.ts
@@ -12,8 +12,7 @@ function getFunctions(region?: firebase.functions.SupportedRegions): FIRFunction
 }
 
 export function httpsCallable<I = {}, O = {}>(functionName: string, region?: firebase.functions.SupportedRegions): HttpsCallable<I, O> {
-
-  const functions = getFunctions();
+  const functions = getFunctions(region);
 
   return (data: I) => new Promise((resolve, reject) => {
 


### PR DESCRIPTION
`getFunctions` should have had the region as its argument on iOS, which was not there, and subsequently caused problem accessing cloud functions on iOS if they are in a different region than `us-central`.