### PR TITLE
Return the GIDSignIn id token when login with Google on iOS

### DIFF
--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -631,7 +631,7 @@ function toLoginResult(user, additionalUserInfo?: FIRAdditionalUserInfo): User {
         providers.push({id: pid, token: FBSDKAccessToken.currentAccessToken ? FBSDKAccessToken.currentAccessToken.tokenString : null});
       } else if (pid === 'google.com' && typeof (GIDSignIn) !== "undefined" && GIDSignIn.sharedInstance() && GIDSignIn.sharedInstance().currentUser) {
         // include web compatible oauth2 token
-        var gidCurrentIdToken = GIDSignIn.sharedInstance().currentUser.authentication.idToken;
+        const gidCurrentIdToken = GIDSignIn.sharedInstance().currentUser.authentication.idToken;
         providers.push({ id: pid, token: gidCurrentIdToken });
       } else {
         providers.push({id: pid});

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -631,8 +631,8 @@ function toLoginResult(user, additionalUserInfo?: FIRAdditionalUserInfo): User {
         providers.push({id: pid, token: FBSDKAccessToken.currentAccessToken ? FBSDKAccessToken.currentAccessToken.tokenString : null});
       } else if (pid === 'google.com' && typeof (GIDSignIn) !== "undefined" && GIDSignIn.sharedInstance() && GIDSignIn.sharedInstance().currentUser) {
         // include web compatible oauth2 token
-        const gidCurrentAccessToken = GIDSignIn.sharedInstance().currentUser.authentication.accessToken;
-        providers.push({id: pid, token: gidCurrentAccessToken });
+        var gidCurrentIdToken = GIDSignIn.sharedInstance().currentUser.authentication.idToken;
+        providers.push({ id: pid, token: gidCurrentIdToken });
       } else {
         providers.push({id: pid});
       }


### PR DESCRIPTION
The token returning from the login with Google on iOS  is the same on both platforms : firebase._googleSignInIdToken on android and GIDSignIn.sharedInstance().currentUser.authentication.idToken on iOS.

https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/1455