### PR TITLE
Feat: extend FirebasePhoneLoginOptions with android timeout parameter

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -444,7 +444,11 @@ Note that changing a password may fail if your login for this `email` was too lo
     type: firebase.LoginType.PHONE,
     phoneOptions: {
       phoneNumber: '+12345678900',
-      verificationPrompt: "The received verification code" // default "Verification code"
+      verificationPrompt: "The received verification code", // default "Verification code"
+      // Optional
+      android: {
+          timeout: 30 // The maximum amount of time you are willing to wait for SMS auto-retrieval to be completed by the library
+      }
     }
   }).then(
       function (result) {

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -985,9 +985,10 @@ firebase.login = arg => {
 
         firebase._verifyPhoneNumberInProgress = true;
 
+        let timeout = arg.phoneOptions.android ? arg.phoneOptions.android.timeout : 60;
         com.google.firebase.auth.PhoneAuthProvider.getInstance().verifyPhoneNumber(
           arg.phoneOptions.phoneNumber,
-          60, // timeout (in seconds, because of the next argument)
+          timeout, // timeout (in seconds, because of the next argument)
           java.util.concurrent.TimeUnit.SECONDS,
           appModule.android.foregroundActivity,
           new OnVerificationStateChangedCallbacks());

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -269,6 +269,11 @@ export interface FirebasePhoneLoginOptions {
    */
   verificationPrompt?: string;
   android?: {
+    /**
+     * The maximum amount of time you are willing to wait for SMS auto-retrieval to be completed by the library. Maximum allowed value is 2 minutes. Use 0 to disable SMS-auto-retrieval. If you specified a positive value less than 30 seconds, library will default to 30 seconds.
+     * Default: 60 (seconds)
+     * See: https://firebase.google.com/docs/reference/android/com/google/firebase/auth/PhoneAuthProvider
+     */
     timeout: number;
   }
 }

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -268,6 +268,9 @@ export interface FirebasePhoneLoginOptions {
    * Default: "Verification code".
    */
   verificationPrompt?: string;
+  android?: {
+    timeout: number;
+  }
 }
 
 export interface FirebaseGoogleLoginOptions {


### PR DESCRIPTION
Possibility to pass timeout parameter for `verifyPhoneNumber` function. https://firebase.google.com/docs/reference/android/com/google/firebase/auth/PhoneAuthProvider.html#verifyPhoneNumber(java.lang.String,%20long,%20java.util.concurrent.TimeUnit,%20java.util.concurrent.Executor,%20com.google.firebase.auth.PhoneAuthProvider.OnVerificationStateChangedCallbacks)