### PR TITLE
fix(android): use application instance from app module

### DIFF
--- a/src/analytics/analytics.android.ts
+++ b/src/analytics/analytics.android.ts
@@ -35,7 +35,7 @@ export function logEvent(options: LogEventOptions): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || appModule.android.nativeApp
       ).logEvent(options.key, bundle);
 
       resolve();
@@ -65,7 +65,7 @@ export function logComplexEvent(options: LogComplexEventOptions): Promise<void> 
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || appModule.android.nativeApp
       ).logEvent(options.key, bundle);
 
       resolve();
@@ -90,7 +90,7 @@ export function setUserId(arg): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance()).setUserId(arg.userId);
+          appModule.android.context || appModule.android.nativeApp).setUserId(arg.userId);
 
       resolve();
     } catch (ex) {
@@ -118,7 +118,7 @@ export function setUserProperty(options: SetUserPropertyOptions): Promise<void> 
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || appModule.android.nativeApp
       ).setUserProperty(options.key, options.value);
 
       resolve();
@@ -143,7 +143,7 @@ export function setScreenName(options: SetScreenNameOptions): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || appModule.android.nativeApp
       ).setCurrentScreen(appModule.android.foregroundActivity, options.screenName, null);
 
       resolve();
@@ -157,7 +157,7 @@ export function setScreenName(options: SetScreenNameOptions): Promise<void> {
 export function setAnalyticsCollectionEnabled(enabled: boolean): void {
   if (isAnalyticsAvailable()) {
     com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-        appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+        appModule.android.context || appModule.android.nativeApp
     ).setAnalyticsCollectionEnabled(enabled);
   }
 }
@@ -165,7 +165,7 @@ export function setAnalyticsCollectionEnabled(enabled: boolean): void {
 export function setSessionTimeoutDuration(seconds: number): void {
   if (isAnalyticsAvailable()) {
     com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-        appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+        appModule.android.context || appModule.android.nativeApp
     ).setSessionTimeoutDuration(seconds * 1000); // Android expects ms
   }
 }

--- a/src/analytics/analytics.android.ts
+++ b/src/analytics/analytics.android.ts
@@ -35,7 +35,7 @@ export function logEvent(options: LogEventOptions): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || appModule.android.nativeApp
+          appModule.android.context || appModule.getNativeApplication()
       ).logEvent(options.key, bundle);
 
       resolve();
@@ -65,7 +65,7 @@ export function logComplexEvent(options: LogComplexEventOptions): Promise<void> 
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || appModule.android.nativeApp
+          appModule.android.context || appModule.getNativeApplication()
       ).logEvent(options.key, bundle);
 
       resolve();
@@ -90,7 +90,7 @@ export function setUserId(arg): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || appModule.android.nativeApp).setUserId(arg.userId);
+          appModule.android.context || appModule.getNativeApplication()).setUserId(arg.userId);
 
       resolve();
     } catch (ex) {
@@ -118,7 +118,7 @@ export function setUserProperty(options: SetUserPropertyOptions): Promise<void> 
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || appModule.android.nativeApp
+          appModule.android.context || appModule.getNativeApplication()
       ).setUserProperty(options.key, options.value);
 
       resolve();
@@ -143,7 +143,7 @@ export function setScreenName(options: SetScreenNameOptions): Promise<void> {
       }
 
       com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || appModule.android.nativeApp
+          appModule.android.context || appModule.getNativeApplication()
       ).setCurrentScreen(appModule.android.foregroundActivity, options.screenName, null);
 
       resolve();
@@ -157,7 +157,7 @@ export function setScreenName(options: SetScreenNameOptions): Promise<void> {
 export function setAnalyticsCollectionEnabled(enabled: boolean): void {
   if (isAnalyticsAvailable()) {
     com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-        appModule.android.context || appModule.android.nativeApp
+        appModule.android.context || appModule.getNativeApplication()
     ).setAnalyticsCollectionEnabled(enabled);
   }
 }
@@ -165,7 +165,7 @@ export function setAnalyticsCollectionEnabled(enabled: boolean): void {
 export function setSessionTimeoutDuration(seconds: number): void {
   if (isAnalyticsAvailable()) {
     com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-        appModule.android.context || appModule.android.nativeApp
+        appModule.android.context || appModule.getNativeApplication()
     ).setSessionTimeoutDuration(seconds * 1000); // Android expects ms
   }
 }

--- a/src/crashlytics/crashlytics.android.ts
+++ b/src/crashlytics/crashlytics.android.ts
@@ -64,7 +64,7 @@ export function crash(): void {
 export function setCrashlyticsCollectionEnabled(enabled: boolean): void {
   if (isCrashlyticsAvailable()) {
     io.fabric.sdk.android.Fabric.with(
-        appModule.android.nativeApp,
+        appModule.getNativeApplication(),
         [new com.crashlytics.android.Crashlytics()]);
   }
 }

--- a/src/crashlytics/crashlytics.android.ts
+++ b/src/crashlytics/crashlytics.android.ts
@@ -1,4 +1,5 @@
 import { ENABLE_CRASHLYTICS_HINT } from "./crashlytics-common";
+import * as appModule from 'tns-core-modules/application';
 
 declare const com: any;
 
@@ -63,7 +64,7 @@ export function crash(): void {
 export function setCrashlyticsCollectionEnabled(enabled: boolean): void {
   if (isCrashlyticsAvailable()) {
     io.fabric.sdk.android.Fabric.with(
-        com.tns.NativeScriptApplication.getInstance(),
+        appModule.android.nativeApp,
         [new com.crashlytics.android.Crashlytics()]);
   }
 }

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -302,14 +302,14 @@ firebase.init = arg => {
 
       if (typeof (com.google.firebase.analytics) !== "undefined" && typeof (com.google.firebase.analytics.FirebaseAnalytics) !== "undefined") {
         com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance()
+          appModule.android.context || appModule.android.nativeApp
         ).setAnalyticsCollectionEnabled(arg.analyticsCollectionEnabled !== false);
       }
 
       // note that this only makes sense if crash reporting was disabled in AndroidManifest.xml
       if (arg.crashlyticsCollectionEnabled && typeof (com.crashlytics) !== "undefined" && typeof (com.crashlytics.android.Crashlytics) !== "undefined") {
         io.fabric.sdk.android.Fabric.with(
-          appModule.android.context || com.tns.NativeScriptApplication.getInstance(),
+          appModule.android.context || appModule.android.nativeApp,
           [new com.crashlytics.android.Crashlytics()]);
       }
 
@@ -478,7 +478,7 @@ firebase.getRemoteConfigDefaults = properties => {
 };
 
 firebase._isGooglePlayServicesAvailable = () => {
-  const ctx = appModule.android.foregroundActivity || appModule.android.startActivity || com.tns.NativeScriptApplication.getInstance();
+  const ctx = appModule.android.foregroundActivity || appModule.android.startActivity || appModule.android.nativeApp;
   const googleApiAvailability = com.google.android.gms.common.GoogleApiAvailability.getInstance();
   const playServiceStatusSuccess = 0; // com.google.android.gms.common.ConnectionResult.SUCCESS;
   const playServicesStatus = googleApiAvailability.isGooglePlayServicesAvailable(ctx);
@@ -1021,7 +1021,7 @@ firebase.login = arg => {
 
         // Lazy loading the Facebook callback manager
         if (!fbCallbackManager) {
-          com.facebook.FacebookSdk.sdkInitialize(com.tns.NativeScriptApplication.getInstance());
+          com.facebook.FacebookSdk.sdkInitialize(appModule.android.nativeApp);
           fbCallbackManager = com.facebook.CallbackManager.Factory.create();
         }
 
@@ -1143,7 +1143,7 @@ firebase.login = arg => {
           }
         });
 
-        firebase._mGoogleApiClient = new com.google.android.gms.common.api.GoogleApiClient.Builder(com.tns.NativeScriptApplication.getInstance())
+        firebase._mGoogleApiClient = new com.google.android.gms.common.api.GoogleApiClient.Builder(appModule.android.nativeApp)
           .addOnConnectionFailedListener(onConnectionFailedListener)
           .addApi(com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
           .build();

--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -302,14 +302,14 @@ firebase.init = arg => {
 
       if (typeof (com.google.firebase.analytics) !== "undefined" && typeof (com.google.firebase.analytics.FirebaseAnalytics) !== "undefined") {
         com.google.firebase.analytics.FirebaseAnalytics.getInstance(
-          appModule.android.context || appModule.android.nativeApp
+          appModule.android.context || appModule.getNativeApplication()
         ).setAnalyticsCollectionEnabled(arg.analyticsCollectionEnabled !== false);
       }
 
       // note that this only makes sense if crash reporting was disabled in AndroidManifest.xml
       if (arg.crashlyticsCollectionEnabled && typeof (com.crashlytics) !== "undefined" && typeof (com.crashlytics.android.Crashlytics) !== "undefined") {
         io.fabric.sdk.android.Fabric.with(
-          appModule.android.context || appModule.android.nativeApp,
+          appModule.android.context || appModule.getNativeApplication(),
           [new com.crashlytics.android.Crashlytics()]);
       }
 
@@ -478,7 +478,7 @@ firebase.getRemoteConfigDefaults = properties => {
 };
 
 firebase._isGooglePlayServicesAvailable = () => {
-  const ctx = appModule.android.foregroundActivity || appModule.android.startActivity || appModule.android.nativeApp;
+  const ctx = appModule.android.foregroundActivity || appModule.android.startActivity || appModule.getNativeApplication();
   const googleApiAvailability = com.google.android.gms.common.GoogleApiAvailability.getInstance();
   const playServiceStatusSuccess = 0; // com.google.android.gms.common.ConnectionResult.SUCCESS;
   const playServicesStatus = googleApiAvailability.isGooglePlayServicesAvailable(ctx);
@@ -1021,7 +1021,7 @@ firebase.login = arg => {
 
         // Lazy loading the Facebook callback manager
         if (!fbCallbackManager) {
-          com.facebook.FacebookSdk.sdkInitialize(appModule.android.nativeApp);
+          com.facebook.FacebookSdk.sdkInitialize(appModule.getNativeApplication());
           fbCallbackManager = com.facebook.CallbackManager.Factory.create();
         }
 
@@ -1143,7 +1143,7 @@ firebase.login = arg => {
           }
         });
 
-        firebase._mGoogleApiClient = new com.google.android.gms.common.api.GoogleApiClient.Builder(appModule.android.nativeApp)
+        firebase._mGoogleApiClient = new com.google.android.gms.common.api.GoogleApiClient.Builder(appModule.getNativeApplication())
           .addOnConnectionFailedListener(onConnectionFailedListener)
           .addApi(com.google.android.gms.auth.api.Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
           .build();


### PR DESCRIPTION
fixes use cases where a custom application is used since `com.tns.NativeScriptApplication.getInstance()` would be null when it is not the starting class 