### PR TITLE
Allow different environments with --release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ Note: if you currently have the `storageBucket` property in the `firebase.init()
 ### Build
 The build hooks of this plugin will now choose either the `dev` or the `prod` version of your google services `plist` and `json` files depending on how you run your build:
 
-* `prod` will be selected if you run with either the `--release`, `--env.prod` or `--env.production` flags
-* `dev` will be selected if you do not run with any of the above flags
+* `dev` will be selected if you run with either `--env.dev`, `--env.development` or `--env.staging` flags.
+* `prod` will be selected if you run with either `--env.prod` or `--env.production`.
+
+Note: Using the `--release` flag without any of the above flags will set the default environment to production. If you need to create a release with dev environment you'll need to set it explicitly.
 
 Note: if you do not have both `dev` and `prod` files in place, the regular `GoogleService-Info.plist` and `google-services.json` files will be used.

--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -825,18 +825,24 @@ module.exports = function($logger, $projectData, hookArgs) {
 return new Promise(function(resolve, reject) {
 
         /* Decide whether to prepare for dev or prod environment */
-        var isReleaseBuild = (hookArgs.appFilesUpdaterOptions || hookArgs.prepareData).release;
+        var validStagingEnvs = ["dev", "development", "staging"];
         var validProdEnvs = ['prod','production'];
         var isProdEnv = false; // building with --env.prod or --env.production flag
+        var isStagingEnv = false;
         var env = (hookArgs.platformSpecificData || hookArgs.prepareData).env;
 
         if (env) {
             Object.keys(env).forEach((key) => {
-                if (validProdEnvs.indexOf(key)>-1) { isProdEnv=true; }
+                if (validProdEnvs.indexOf(key)>-1) { 
+			isProdEnv = true;
+		}
+		if (validStagingEnvs.indexOf(key) > -1) {
+			isStagingEnv = true;
+		}
             });
         }
 
-        var buildType = isReleaseBuild || isProdEnv ? 'production' : 'development';
+        var buildType = isProdEnv && !isStagingEnv ? "production" : "development";
         const platformFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
         const platform = (platformFromHookArgs  || '').toLowerCase();
 

--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -3623,18 +3623,24 @@ module.exports = function($logger, $projectData, hookArgs) {
 return new Promise(function(resolve, reject) {
 
         /* Decide whether to prepare for dev or prod environment */
-        var isReleaseBuild = (hookArgs.appFilesUpdaterOptions || hookArgs.prepareData).release;
+        var validStagingEnvs = ["dev", "development", "staging"];
         var validProdEnvs = ['prod','production'];
         var isProdEnv = false; // building with --env.prod or --env.production flag
+	var isStagingEnv = false;
         var env = (hookArgs.platformSpecificData || hookArgs.prepareData).env;
 
         if (env) {
             Object.keys(env).forEach((key) => {
-                if (validProdEnvs.indexOf(key)>-1) { isProdEnv=true; }
+                if (validProdEnvs.indexOf(key)>-1) {
+			isProdEnv=true;
+		}
+		if (validStagingEnvs.indexOf(key) > -1) {
+			isStagingEnv = true;
+		}
             });
         }
 
-        var buildType = isReleaseBuild || isProdEnv ? 'production' : 'development';
+        var buildType = isProdEnv && !isStagingEnv ? "production" : "development";
         const platformFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
         const platform = (platformFromHookArgs  || '').toLowerCase();
 


### PR DESCRIPTION
Currently is not possible to create builds with the auto environment assigning because the `--release` tag always sets the firebase production environment.

To check the current environment, this PR is checking if the env is production and NOT staging/development. Breaking changes are avoided and the users got to use --release with either environment.

Since all versions > 10 of this plugin are supposed to work with NS6.1 or superior, I believe using `--release` to check the environment is redundant since `--release` sets production to true by default.