### PR TITLE
Disable Direct Channel API on iOS

### DIFF
--- a/src/messaging/messaging.ios.ts
+++ b/src/messaging/messaging.ios.ts
@@ -251,10 +251,6 @@ export function prepAppDelegate() {
 
   _addObserver(UIApplicationDidBecomeActiveNotification, appNotification => {
     _processPendingNotifications();
-
-    if (typeof (FIRMessaging) !== "undefined") {
-      FIRMessaging.messaging().shouldEstablishDirectChannel = false;
-    }
   });
 }
 

--- a/src/messaging/messaging.ios.ts
+++ b/src/messaging/messaging.ios.ts
@@ -253,7 +253,7 @@ export function prepAppDelegate() {
     _processPendingNotifications();
 
     if (typeof (FIRMessaging) !== "undefined") {
-      FIRMessaging.messaging().shouldEstablishDirectChannel = true;
+      FIRMessaging.messaging().shouldEstablishDirectChannel = false;
     }
   });
 }


### PR DESCRIPTION
Direct Channel API is deprecated and will be removed in the next releases of the FirebaseSDK

Same issue on React-Native
https://github.com/invertase/react-native-firebase/issues/3674
https://github.com/invertase/react-native-firebase/pull/3733

Closes #1609 