### PR TITLE
Apple sign in for iOS fix / workaround

### DIFF
--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -947,12 +947,11 @@ firebase.login = arg => {
         appleIDRequest.nonce = sha256Nonce;
 
         const authorizationController = ASAuthorizationController.alloc().initWithAuthorizationRequests([appleIDRequest]);
-        const delegate = ASAuthorizationControllerDelegateImpl.createWithOwnerAndResolveReject(new WeakRef(this), resolve, reject);
+        const delegate = ASAuthorizationControllerDelegateImpl.createWithOwnerAndResolveReject(this, resolve, reject);
         CFRetain(delegate);
         authorizationController.delegate = delegate;
 
-        authorizationController.presentationContextProvider = ASAuthorizationControllerPresentationContextProvidingImpl.createWithOwnerAndCallback(
-            new WeakRef(this));
+        authorizationController.presentationContextProvider = ASAuthorizationControllerPresentationContextProvidingImpl.createWithOwnerAndCallback(this);
 
         authorizationController.performRequests();
 


### PR DESCRIPTION
I don't know if this is the right fix but it doesn't break anything and it makes Apple Sign in work again on iOS.

Since nobody have time to actually investigate and fix this problem I'm making this pull request with suggested fix / workaround from [**ngocnt1**](https://github.com/ngocnt1) in issue #1660 to attract more attention from someone that could actually investigate this problem or at least merge this pull request so people could use Apple Sign in on iOS again.