### PR TITLE
Fix #1683 NS7+Ng10 Admob Smartbanner error: Invalid ad width or height: (0, 0) on v11.0.0

### DIFF
--- a/src/admob/admob.ios.ts
+++ b/src/admob/admob.ios.ts
@@ -39,7 +39,7 @@ export function showBanner(arg: BannerOptions): Promise<any> {
 
         //Fix for the smart banner size on NS7.0+, due to issue with initWithAdSizeOrigin response "Invalid ad width or height: (0, 0)"
         if (settings.size === AD_SIZE.SMART_BANNER) {
-            const adFrameRec = CGRectMake(originX, originY, adWidth, Math.min(adHeight, 50)); // minimum height should be 50 for a ad banner
+            const adFrameRec = CGRectMake(originX, originY, adWidth, adHeight); 
             firebase.admob.adView = GADBannerView.alloc().initWithFrame(adFrameRec)
         } else {
             const origin = CGPointMake(originX, originY);

--- a/src/admob/admob.ios.ts
+++ b/src/admob/admob.ios.ts
@@ -36,9 +36,15 @@ export function showBanner(arg: BannerOptions): Promise<any> {
 
       const originX = (view.frame.size.width - adWidth) / 2;
       const originY = settings.margins.top > -1 ? settings.margins.top : (settings.margins.bottom > -1 ? view.frame.size.height - adHeight - settings.margins.bottom : 0.0);
-      const origin = CGPointMake(originX, originY);
-      firebase.admob.adView = GADBannerView.alloc().initWithAdSizeOrigin(bannerType, origin);
 
+        //Fix for the smart banner size on NS7.0+, due to issue with initWithAdSizeOrigin response "Invalid ad width or height: (0, 0)"
+        if (settings.size === AD_SIZE.SMART_BANNER) {
+            const adFrameRec = CGRectMake(originX, originY, adWidth, Math.min(adHeight, 50)); // minimum height should be 50 for a ad banner
+            firebase.admob.adView = GADBannerView.alloc().initWithFrame(adFrameRec)
+        } else {
+            const origin = CGPointMake(originX, originY);
+            firebase.admob.adView = GADBannerView.alloc().initWithAdSizeOrigin(bannerType, origin);
+        }
       firebase.admob.adView.adUnitID = settings.iosBannerId;
 
       const adRequest = GADRequest.request();


### PR DESCRIPTION
Please see more in #1683