### PR TITLE
fix(ios): FirebaseCrashlytics release mode and delegate handling improvements

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -455,7 +455,7 @@ const pattern3 = /\\n\\s*\\/\\/Crashlytics 3 BEGIN[\\s\\S]*\\/\\/Crashlytics 3 E
 const string1 = \`
 //Crashlytics 1 BEGIN
 #else
-@import FirebaseCrashlytics;
+#import <FirebaseCrashlytics/FirebaseCrashlytics.h>;
 #endif
 //Crashlytics 1 END
 \`;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/firebase",
-  "version": "11.1.0",
+  "version": "11.1.1-rc.0",
   "description": "Fire. Base. Firebase!",
   "main": "firebase",
   "typings": "index.d.ts",


### PR DESCRIPTION
* [x] fixes FirebaseCrashlytics import in release mode (see attachments) - When building in release mode for store upload the module import would cause error
* [x] improves delegate handling to retain on the `firebase` symbol to avoid occasional early garbage collection by v8 engine
* [x] fixes random crash when trying to login with Google on iOS with {N} 7

This is published under `rc` right now with @nativescript/firebase `11.1.1-rc.0` if anyone experiences issues related to above can try and please confirm here if it solved it for you.

<img width="944" alt="Screen Shot 2020-11-01 at 8 16 35 AM" src="https://user-images.githubusercontent.com/457187/97810121-6c862e00-1c26-11eb-953e-12bd4807146d.png">
