### PR TITLE
Ignore callbacks for previous phone number auth entered

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -1031,6 +1031,7 @@ firebase.login = arg => {
       firebase.moveLoginOptionsToObjects(arg);
 
       const firebaseAuth = com.google.firebase.auth.FirebaseAuth.getInstance();
+      let phoneAuthVerificationId = "";
       const onCompleteListener = new gmsTasks.OnCompleteListener({
         onComplete: task => {
           if (!task.isSuccessful()) {
@@ -1151,6 +1152,8 @@ firebase.login = arg => {
             }
           },
           onCodeSent: (verificationId, forceResendingToken) => {
+            // Keep track of the 'current' verificationId to avoid conflicts with previous ones wrongly input
+            phoneAuthVerificationId = verificationId;
             // If the device has a SIM card auto-verification may occur in the background (eventually calling onVerificationCompleted)
             // .. so the prompt would be redundant, but it's recommended by Google not to wait to long before showing the prompt
             setTimeout(() => {
@@ -1159,6 +1162,8 @@ firebase.login = arg => {
                 firebase.requestPhoneAuthVerificationCode(userResponse => {
                   if (userResponse === undefined && firebase.reject) {
                     firebase.reject("Prompt was canceled");
+                    return;
+                  } else if (phoneAuthVerificationId !== verificationId) {
                     return;
                   }
                   const authCredential = com.google.firebase.auth.PhoneAuthProvider.getCredential(verificationId, userResponse);

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -919,6 +919,7 @@ firebase.getAuthToken = (arg: GetAuthTokenOptions): Promise<IdTokenResult> => {
 firebase.login = arg => {
   return new Promise((resolve, reject) => {
     try {
+      let phoneAuthVerificationId = "";
       const onCompletionWithAuthResult = (authResult: FIRAuthDataResult, error?: NSError) => {
         if (error) {
           // also disconnect from Google otherwise ppl can't connect with a different account
@@ -1021,10 +1022,14 @@ firebase.login = arg => {
             reject(error.localizedDescription);
             return;
           }
+          // Keep track of the 'current' verificationId to avoid conflicts with previous ones wrongly input
+          phoneAuthVerificationId = verificationID;
 
           firebase.requestPhoneAuthVerificationCode(userResponse => {
             if (userResponse === undefined) {
               reject("Prompt was canceled");
+              return;
+            } else if (phoneAuthVerificationId !== verificationID) {
               return;
             }
             const fIRAuthCredential = FIRPhoneAuthProvider.provider().credentialWithVerificationIDVerificationCode(verificationID, userResponse);


### PR DESCRIPTION
**Prerequisite**

Disable android timeout by setting it to 0

**Context**

On every call to `login` type phone, Firebase generates a verification id. If this function is called several times before submitting an SMS code, at the time this happens, Firebase returns all the verification ids accumulated to the `onCodeSent->requestPhoneAuthVerificationCode` (android) or `credentialWithVerificationIDVerificationCode` (iOS) one by one.

**Use Case**

A user enters a phone number and clicks on login. Then the user realizes the phone number is wrong, resets the form, sets a proper number, clicks on login, gets an SMS code and submit this code to verify the login.

**Steps to reproduce**

1. Enter wrong number, trigger login but do not verify it by entering SMS code.
3. Enter correct number, trigger login and enter SMS code.
4. Firebase returns a user
5. Either queries to Firestore return permission denied or edge where 1st user logs in (more details in Observed results).

**Observed Results**

It generates 2 different callbacks to `requestPhoneAuthVerificationCode(android)/credentialWithVerificationIDVerificationCode(iOS)`. I found out 2 different outcomes so far.

1. After the user is logged in, Firestore rules return permission denied.
2. Only possible to reproduce by setting in the Firebase console 2 test phone numbers, which have the same SMS code. If phone number A and phone number B have the same SMS code, after following the steps to reproduce, phone number A will be logged in instead of B.

**Expected Results**

The last phone number sent to the login function should be the only one logging in.

**Solution proposed**

1. Keep track of the 'current' `verificationId` to verify, in a variable.
2. As soon as `onCodeSent` receives the `verificationId`, save the 'current' `verificationId` in a the variable. Each callback can now reference a snapshot of the `verificationId` that is being verified.
3. In the `requestPhoneAuthVerificationCode(android)/credentialWithVerificationIDVerificationCode(iOS)` function of the OnVerificationStateChangedCallbacks object that is passed to verifyPhoneNumber, check if the actual 'current' `verificationId` to verify is equal to the `verificationId` that was captured/enclosed by the callback object -- if the `verificationId` don't match, stop execution.
