### PR TITLE
iOS: Fix ignoring region param after first cache

### DIFF
--- a/src/functions/functions.ios.ts
+++ b/src/functions/functions.ios.ts
@@ -2,13 +2,9 @@ import * as firebase from "../firebase";
 import { firebaseUtils } from '../utils';
 import { HttpsCallable } from './functions';
 
-let functions: FIRFunctions;
 
 function getFunctions(region?: firebase.firebaseFunctions.SupportedRegions): FIRFunctions {
-  if (!functions) {
-    functions = region ? FIRFunctions.functionsForRegion(region) : FIRFunctions.functions();
-  }
-  return functions;
+  return region ? FIRFunctions.functionsForRegion(region) : FIRFunctions.functions();
 }
 
 export function httpsCallable<I = {}, O = {}>(functionName: string, region?: firebase.firebaseFunctions.SupportedRegions): HttpsCallable<I, O> {


### PR DESCRIPTION
Currently it is not possible to properly use region specific functions in iOS unless all calls are made to a single region, due to the way this broken caching mechanism works.