### PR TITLE
Fix/after prepare env release

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -727,6 +727,7 @@ return new Promise(function(resolve, reject) {
         var isProdEnv = false; // building with --env.prod or --env.production flag
         var isStagingEnv = false;
         var env = (hookArgs.platformSpecificData || hookArgs.prepareData).env;
+        var isReleaseBuild = !!(hookArgs.prepareData).release;
 
         if (env) {
             Object.keys(env).forEach((key) => {
@@ -739,10 +740,10 @@ return new Promise(function(resolve, reject) {
             });
         }
 
-        var buildType = isProdEnv && !isStagingEnv ? "production" : "development";
         const platformFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
         const platform = (platformFromHookArgs  || '').toLowerCase();
 
+        var buildType = (isReleaseBuild && !isStagingEnv) || isProdEnv ? 'production' : 'development';
         /* Create info file in platforms dir so we can detect changes in environment and force prepare if needed */
 
         var npfInfoPath = path.join($projectData.platformsDir, platform, ".pluginfirebaseinfo");

--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -744,8 +744,8 @@ return new Promise(function(resolve, reject) {
         const platform = (platformFromHookArgs  || '').toLowerCase();
 
         var buildType = (isReleaseBuild && !isStagingEnv) || isProdEnv ? 'production' : 'development';
+        
         /* Create info file in platforms dir so we can detect changes in environment and force prepare if needed */
-
         var npfInfoPath = path.join($projectData.platformsDir, platform, ".pluginfirebaseinfo");
         var npfInfo = {
             buildType: buildType,
@@ -756,9 +756,7 @@ return new Promise(function(resolve, reject) {
             $logger.info('nativescript-plugin-firebase: unable to create '+npfInfoPath+', prepare will be forced next time!');
         }
 
-
         /* Handle preparing of Google Services files */
-
         if (platform === 'android') {
             var destinationGoogleJson = path.join($projectData.platformsDir, "android", "app", "google-services.json");
             var destinationGoogleJsonAlt = path.join($projectData.platformsDir, "android", "google-services.json");
@@ -768,8 +766,7 @@ return new Promise(function(resolve, reject) {
 
             // ensure we have both dev/prod versions so we never overwrite singlular google-services.json
             if (fs.existsSync(sourceGoogleJsonProd) && fs.existsSync(sourceGoogleJsonDev)) {
-                if (buildType==='production') { sourceGoogleJson = sourceGoogleJsonProd; } // use prod version
-                else { sourceGoogleJson = sourceGoogleJsonDev; } // use dev version
+                sourceGoogleJson = buildType === 'production' ? sourceGoogleJsonProd : sourceGoogleJsonDev
             }
 
             // copy correct version to destination
@@ -804,6 +801,7 @@ return new Promise(function(resolve, reject) {
         }
     });
 };
+
 `;
     var scriptPath = path.join(appRoot, "hooks", "after-prepare", "firebase-copy-google-services.js");
     var afterPrepareDirPath = path.dirname(scriptPath);
@@ -835,7 +833,6 @@ module.exports = function($logger, hookArgs) {
     return new Promise(function(resolve, reject) {
 
         /* Decide whether to prepare for dev or prod environment */
-
         var isReleaseBuild = !!((hookArgs.checkForChangesOpts && hookArgs.checkForChangesOpts.projectChangesOptions) || hookArgs.prepareData).release;
         var validProdEnvs = ['prod','production'];
         var validStagingEnvs = ["dev", "development", "staging"];
@@ -873,11 +870,11 @@ module.exports = function($logger, hookArgs) {
             try { npfInfo = JSON.parse(fs.readFileSync(npfInfoPath, 'utf8')); }
             catch (e) { $logger.info('nativescript-plugin-firebase: error reading '+npfInfoPath); }
 
-            if (npfInfo && npfInfo.hasOwnProperty('buildType') && npfInfo.buildType===buildType) {
+            if (npfInfo && npfInfo.hasOwnProperty('buildType') && npfInfo.buildType === buildType) {
                 $logger.info('nativescript-plugin-firebase: building for same environment, not forcing prepare.');
-                forcePrepare=false;
+                forcePrepare = false;
             }
-        } else { $logger.info('nativescript-plugin-firebase: '+npfInfoPath+' not found, forcing prepare!'); }
+        } else { $logger.info('nativescript-plugin-firebase: ' + npfInfoPath + ' not found, forcing prepare!'); }
 
         if (forcePrepare) {
             $logger.info('nativescript-plugin-firebase: running release build or change in environment detected, forcing prepare!');
@@ -902,7 +899,7 @@ var copyPlist = function(copyPlistOpts) {
 
         // if we have both dev/prod versions, we copy (or overwrite) GoogleService-Info.plist in destination dir
         if (fs.existsSync(sourceGooglePlistProd) && fs.existsSync(sourceGooglePlistDev)) {
-            if (copyPlistOpts.buildType==='production') { // use prod version
+            if (copyPlistOpts.buildType === 'production') { // use prod version
                 copyPlistOpts.$logger.info("nativescript-plugin-firebase: copy " + sourceGooglePlistProd + " to " + destinationGooglePlist + ".");
                 fs.writeFileSync(destinationGooglePlist, fs.readFileSync(sourceGooglePlistProd));
                 return true;


### PR DESCRIPTION
The current after-prepare hook's check to determine what env - 'production' or 'development' - it is building for does not match the check used in the before-checkForChanges hook. Specifically, it does not identify we are performing a production build if the release flag is set, unless env.production or env.prod are specified.

I have also simplified and made sure the way isProdEnv and isStagingEnv are computed is consistent across the two scripts.