### PR TITLE
Feature: Add isEqual on Query and CollectionReference

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -2531,7 +2531,9 @@ firebase.firestore._getCollectionReference = (colRef?: JCollectionReference): fi
     startAfter: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.startAfter(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
     startAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.startAt(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
     endAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endAt(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
-    endBefore: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endBefore(collectionPath, snapshotOrFieldValue, fieldValues, colRef)
+    endBefore: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endBefore(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
+    android: colRef,
+    isEqual: (other: firestore.Query): boolean => colRef.equals(other ? other.android : null)
   };
 };
 
@@ -2780,7 +2782,9 @@ firebase.firestore._getQuery = (collectionPath: string, query: com.google.fireba
     startAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.startAt(collectionPath, snapshotOrFieldValue, fieldValues, query),
     endAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endAt(collectionPath, snapshotOrFieldValue, fieldValues, query),
     endBefore: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endBefore(collectionPath, snapshotOrFieldValue, fieldValues, query),
-    firestore: firebase.firestore
+    firestore: firebase.firestore,
+    android: query,
+    isEqual: (other: firestore.Query): boolean => query.equals(other ? other.android : null)
   };
 };
 

--- a/src/firebase.d.ts
+++ b/src/firebase.d.ts
@@ -1000,6 +1000,12 @@ export namespace firestore {
     endBefore(snapshot: DocumentSnapshot): Query;
 
     endBefore(...fieldValues: any[]): Query;
+
+    ios?: FIRQuery;
+
+    android?: com.google.firebase.firestore.Query;
+
+    isEqual: (other: firestore.Query) => boolean;
   }
 
   export interface CollectionGroup {

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -2144,7 +2144,9 @@ firebase.firestore._getCollectionReference = (colRef?: FIRCollectionReference): 
     startAfter: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.startAfter(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
     startAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.startAt(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
     endAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endAt(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
-    endBefore: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endBefore(collectionPath, snapshotOrFieldValue, fieldValues, colRef)
+    endBefore: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endBefore(collectionPath, snapshotOrFieldValue, fieldValues, colRef),
+    ios: colRef,
+    isEqual: (other: firestore.Query): boolean => colRef.isEqual(other ? other.ios : null)
   };
 };
 
@@ -2437,7 +2439,9 @@ firebase.firestore._getQuery = (collectionPath: string, query: FIRQuery): firest
     startAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.startAt(collectionPath, snapshotOrFieldValue, fieldValues, query),
     endAt: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endAt(collectionPath, snapshotOrFieldValue, fieldValues, query),
     endBefore: (snapshotOrFieldValue: DocumentSnapshot | any, ...fieldValues: any[]): firestore.Query => firebase.firestore.endBefore(collectionPath, snapshotOrFieldValue, fieldValues, query),
-    firestore: firebase.firestore
+    firestore: firebase.firestore,
+    ios: query,
+    isEqual: (other: firestore.Query): boolean => query.isEqual(other ? other.ios : null)
   };
 };
 

--- a/src/platforms/ios/typings/objc!FirebaseFirestore.d.ts
+++ b/src/platforms/ios/typings/objc!FirebaseFirestore.d.ts
@@ -294,6 +294,8 @@ declare class FIRQuery extends NSObject {
 
 	addSnapshotListenerWithIncludeMetadataChangesListener(includeMetadataChanges: boolean, listener: (p1: FIRQuerySnapshot, p2: NSError) => void): FIRListenerRegistration;
 
+	isEqual(other: FIRQuery): boolean;
+
 	getDocumentsWithCompletion(completion: (p1: FIRQuerySnapshot, p2: NSError) => void): void;
 
 	getDocumentsWithSourceCompletion(source: FIRFirestoreSource, completion: (p1: FIRQuerySnapshot, p2: NSError) => void): void;


### PR DESCRIPTION
Useful if we generate Queries dynamically with different where and orderBy clauses and want to check if the resultant Query is the same as one we are already using in a snapshot watcher.