### PR TITLE
Feature/support field path

### DIFF
--- a/src/firebase.android.ts
+++ b/src/firebase.android.ts
@@ -2933,5 +2933,10 @@ export class QuerySnapshot implements firestore.QuerySnapshot {
     this.docSnapshots.map(snapshot => callback(snapshot));
   }
 }
+firebase.firestore.FieldPath = class {
+  static documentId() {
+    return com.google.firebase.firestore.FieldPath.documentId();
+  }
+}
 
 export * from './firebase-common';

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -2441,30 +2441,32 @@ firebase.firestore._getQuery = (collectionPath: string, query: FIRQuery): firest
   };
 };
 
-firebase.firestore.where = (collectionPath: string, fieldPath: string, opStr: firestore.WhereFilterOp, value: any, query?: FIRQuery): firestore.Query => {
+firebase.firestore.where = (collectionPath: string, fieldPath: string | FIRFieldPath, opStr: firestore.WhereFilterOp, value: any, query?: FIRQuery): firestore.Query => {
   ensureFirestore();
   try {
     query = query || FIRFirestore.firestore().collectionWithPath(collectionPath);
     value = fixSpecialField(value);
 
+    let queryFieldPathType = fieldPath instanceof FIRFieldPath ? 'FieldPath' : 'Field'
+
     if (opStr === "<") {
-      query = query.queryWhereFieldIsLessThan(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}IsLessThan`](fieldPath, value);
     } else if (opStr === "<=") {
-      query = query.queryWhereFieldIsLessThanOrEqualTo(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}IsLessThanOrEqualTo`](fieldPath, value);
     } else if (opStr === "==") {
-      query = query.queryWhereFieldIsEqualTo(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}IsEqualTo`](fieldPath, value);
     } else if (opStr === ">=") {
-      query = query.queryWhereFieldIsGreaterThanOrEqualTo(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}IsGreaterThanOrEqualTo`](fieldPath, value);
     } else if (opStr === ">") {
-      query = query.queryWhereFieldIsGreaterThan(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}IsGreaterThan`](fieldPath, value);
     } else if (opStr === "array-contains") {
-      query = query.queryWhereFieldArrayContains(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}ArrayContains`](fieldPath, value);
     } else if (opStr === "array-contains-any") {
-      query = query.queryWhereFieldArrayContainsAny(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}ArrayContainsAny`](fieldPath, value);
     } else if (opStr === "in") {
-      query = query.queryWhereFieldIn(fieldPath, value);
+      query = query[`queryWhere${queryFieldPathType}In`](fieldPath, value);
     } else {
-      console.log("Illegal argument for opStr: " + opStr);
+      console.error("Illegal argument for opStr: " + opStr);
       return null;
     }
 

--- a/src/firebase.ios.ts
+++ b/src/firebase.ios.ts
@@ -2519,6 +2519,11 @@ firebase.firestore.endBefore = (collectionPath: string, snapshotOrFieldValue: Do
     return firebase.firestore._getQuery(collectionPath, query.queryEndingBeforeValues([snapshotOrFieldValue, ...fieldValues]));
   }
 };
+firebase.firestore.FieldPath = class {
+  static documentId() {
+    return FIRFieldPath.documentID();
+  }
+}
 
 @NativeClass()
 class GIDSignInDelegateImpl extends NSObject implements GIDSignInDelegate {


### PR DESCRIPTION
Support use of FieldPath objects (`firebase.firestore.FieldPath.documentId()`) in queries, for example if we need to query for a few specific documents by their document Id:

```javascript
return firebase.firestore.collection('someCollection')
    .where(firebase.firestore.FieldPath.documentId(), 'in', arrayOfDocIds)
```