### PR TITLE
Update Facebook SDK to latest

### DIFF
--- a/publish/scripts/installer.js
+++ b/publish/scripts/installer.js
@@ -682,8 +682,8 @@ dependencies {
     ` + (isSelected(result.ml_kit_natural_language_smartreply) ? `` : `//`) + ` implementation "com.google.firebase:firebase-ml-natural-language-smart-reply-model:20.0.7"
 
     // Facebook Authentication
-    ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` implementation "com.facebook.android:facebook-core:5.4.0"
-    ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` implementation "com.facebook.android:facebook-login:5.4.0"
+    ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` implementation "com.facebook.android:facebook-core:12.0.1"
+    ` + (isSelected(result.facebook_auth) ? `` : `//`) + ` implementation "com.facebook.android:facebook-login:12.0.1"
 
     // Google Sign-In Authentication
     ` + (isSelected(result.google_auth) ? `` : `//`) + ` implementation "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"


### PR DESCRIPTION
Android version was pinned to v5 whereas Facebook recently requires a more recent version (latest major is v12) due to security considerations where the previously used webview is not allowed anymore and prevents Android users from using FB auth.